### PR TITLE
chore: add mobile ignores and CI cache paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,11 @@ jobs:
         with:
           node-version: 20
           cache: npm
+          cache-dependency-path: apps/web/package-lock.json
       - run: npm ci
       - run: npm run lint
       - run: npm run build
-      - run: npm test --if-present
+      - run: npm test
   mobile:
     runs-on: ubuntu-latest
     defaults:
@@ -32,8 +33,9 @@ jobs:
         with:
           node-version: 20
           cache: npm
+          cache-dependency-path: apps/mobile/package-lock.json
       - run: npm ci
       - run: npm run lint
       - run: npm run build
       - run: npm run align
-      - run: npm test --if-present
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ out/
 .expo/
 .expo-shared/
 expo-build/
+android/
+ios/
 
 # Caches
 .cache/


### PR DESCRIPTION
## Summary
- ignore native folders generated by Expo
- tighten CI by caching lockfiles and removing conditional tests

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a577216c832fb7ea518e8cfb6c00