### PR TITLE
feat(web): refine brand theming

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3,13 +3,21 @@
 @tailwind utilities;
 
 :root {
-  color-scheme: dark;
-  --background: #0B0B0B;
-  --surface: #111111;
+  --background: #ffffff;
+  --surface: #f5f5f5;
+  --foreground: #000000;
   --lime: #D1FF3D;
   --purple: #873BBF;
 }
 
-body {
-  @apply bg-background text-lime;
+.dark {
+  --background: #0B0B0B;
+  --surface: #111111;
+  --foreground: #D1FF3D;
+}
+
+@layer base {
+  body {
+    @apply bg-background text-foreground;
+  }
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -7,8 +7,8 @@ const mono = Source_Code_Pro({ subsets: ['latin'], variable: '--font-mono' });
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className={`dark ${inter.variable} ${mono.variable}`}>
-      <body className="bg-background text-lime">{children}</body>
+    <html lang="en" className="dark">
+      <body className={`${inter.variable} ${mono.variable} bg-background text-foreground`}>{children}</body>
     </html>
   );
 }

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -8,6 +8,7 @@ const config: Config = {
       colors: {
         background: 'var(--background)',
         surface: 'var(--surface)',
+        foreground: 'var(--foreground)',
         lime: 'var(--lime)',
         purple: 'var(--purple)'
       },


### PR DESCRIPTION
## Summary
- wire dark-mode brand color tokens via CSS variables
- apply font variables and brand colors in layout
- extend Tailwind config with foreground token

## Testing
- `npm run lint`
- `npm run build`
- `npm test -- --run`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68b8ae1b0350832f968abbd9ef2a402f