### PR TITLE
chore: mobile expo guard and landing cleanup

### DIFF
--- a/apps/mobile/.eslintrc.cjs
+++ b/apps/mobile/.eslintrc.cjs
@@ -3,13 +3,11 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
-
   env: { node: true, es2021: true },
-
   ignorePatterns: ['node_modules'],
   settings: {
     'import/resolver': {
-      alias: { map: [['@', './src']] }
-    }
-  }
+      alias: { map: [['@', './src']] },
+    },
+  },
 };

--- a/apps/mobile/src/screens/Landing.tsx
+++ b/apps/mobile/src/screens/Landing.tsx
@@ -2,14 +2,9 @@ import { View, Text } from 'react-native';
 import { theme } from '../theme';
 import type { ComponentType } from 'react';
 
-
 let MarketingLanding: ComponentType<Record<string, unknown>> | null = null;
 try {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-
-let MarketingLanding: ComponentType<any> | null = null;
-try {
-
   MarketingLanding = require('../../../../MarketingLanding.svg').default;
 } catch {
   MarketingLanding = null;


### PR DESCRIPTION
## Summary
- clean landing screen import logic
- simplify mobile eslint config

## Testing
- `npm test`
- `npm run align` *(fails: fetch failed for expo doctor)*
- `node -e "try { require('./metro.config').resolver.extraNodeModules.http } catch (e) { console.error('guard:', e.message); }"`


------
https://chatgpt.com/codex/tasks/task_e_68b932842948832fba1d6afe00c30b2a