### PR TITLE
chore: wire up supabase configs

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -21,5 +21,9 @@ supabase login
 supabase link --project-ref <PROJECT_REF>
 supabase functions deploy --no-verify-jwt
 cd ..
+```
+
+### Apply RLS policies
+```bash
 supabase db connect < supabase/sql/rls_policies.sql
 ```

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -3,6 +3,6 @@ export default {
   out: './packages/db/migrations',
   driver: 'pg',
   dbCredentials: {
-    connectionString: process.env.DATABASE_URL ?? ''
+    connectionString: process.env.DRIZZLE_DATABASE_URL ?? ''
   }
 };

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2,8 +2,8 @@ import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 import * as schema from './schema';
 
-declare const process: { env: { DATABASE_URL?: string } };
+declare const process: { env: { DRIZZLE_DATABASE_URL?: string } };
 
-const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+const pool = new Pool({ connectionString: process.env.DRIZZLE_DATABASE_URL });
 export const db = drizzle(pool, { schema });
 export { schema };

--- a/supabase/sql/rls_policies.sql
+++ b/supabase/sql/rls_policies.sql
@@ -115,7 +115,7 @@ insert into storage.buckets (id, name, public) values ('memes','memes',false) on
 -- Storage policies
 create policy "Public read media files" on storage.objects for select using (bucket_id in ('media','memes'));
 create policy "Upload own media files" on storage.objects for insert with check (
-  bucket_id in ('media','memes') and auth.uid() = owner
+  bucket_id in ('media','memes') and (auth.uid() = owner or auth.jwt() ->> 'role' = 'admin')
 );
 create policy "Update own media files" on storage.objects for update using (
   bucket_id in ('media','memes') and (auth.uid() = owner or auth.jwt() ->> 'role' = 'admin')


### PR DESCRIPTION
## Summary
- switch db package to `DRIZZLE_DATABASE_URL`
- document applying RLS policies during deployment
- allow admins to upload to Supabase storage buckets

## Testing
- `npm run lint:db`
- `npm run lint:web`
- `npm run build:web`
- `npm run lint:mobile`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b960ff7950832f807581d6828b819d