### PR TITLE
feat(mobile): align expo sdk50

### DIFF
--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -1,17 +1,53 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { getDefaultConfig } = require('expo/metro-config');
 
+/**
+ * Expo-first Metro config with:
+ *  - Node core module guard (prevents bundling http/fs/path/etc. into RN)
+ *  - disableHierarchicalLookup hardening
+ *  - Optional react-native-svg-transformer (if installed)
+ */
 const config = getDefaultConfig(__dirname);
 
 config.resolver.disableHierarchicalLookup = true;
-const forbidden = ['http','https','url','fs','path','zlib','stream','crypto','util','net','tls','events'];
-config.resolver.extraNodeModules = new Proxy({}, {
-  get(_target, name) {
-    if (forbidden.includes(name)) {
-      throw new Error(`FORBIDDEN import of ${String(name)}`);
-    }
-    return require('node-libs-react-native')[name] || name;
+
+// --- Guard: forbid Node core modules in app code
+const FORBIDDEN = new Set([
+  'http',
+  'https',
+  'url',
+  'fs',
+  'path',
+  'zlib',
+  'stream',
+  'crypto',
+  'util',
+  'net',
+  'tls',
+  'events'
+]);
+const originalResolveRequest = config.resolver.resolveRequest;
+config.resolver.resolveRequest = function (context, moduleName, platform) {
+  if (FORBIDDEN.has(moduleName)) {
+    throw new Error(
+      `[mobile] Node builtin "${moduleName}" imported — not supported in React Native/Hermes.`
+    );
   }
-});
+  if (typeof originalResolveRequest === 'function') {
+    return originalResolveRequest(context, moduleName, platform);
+  }
+  return context.resolveRequest(moduleName, platform);
+};
+
+// Optional react-native-svg-transformer
+try {
+  const svgTransformer = require.resolve('react-native-svg-transformer');
+  config.transformer.babelTransformerPath = svgTransformer;
+  const { assetExts, sourceExts } = config.resolver;
+  config.resolver.assetExts = assetExts.filter((ext) => ext !== 'svg');
+  config.resolver.sourceExts = [...sourceExts, 'svg'];
+} catch {
+  // transformer not installed; ignore
+}
 
 module.exports = config;

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -14,15 +14,15 @@
         "@tanstack/query-sync-storage-persister": "5.85.9",
         "@tanstack/react-query": "5.85.9",
         "@tanstack/react-query-persist-client": "5.85.9",
-        "expo": "50.0.7",
+        "expo": "~50.0.20",
         "expo-font": "11.10.3",
-        "expo-image": "2.4.0",
-        "expo-image-manipulator": "^13.1.7",
-        "expo-image-picker": "16.1.4",
+        "expo-image": "~1.10.6",
+        "expo-image-manipulator": "~11.8.0",
+        "expo-image-picker": "~14.7.1",
         "react": "18.2.0",
         "react-native": "0.73.6",
         "react-native-gesture-handler": "2.14.0",
-        "react-native-maps": "1.14.0",
+        "react-native-maps": "1.10.0",
         "react-native-mmkv": "2.10.2",
         "react-native-reanimated": "3.6.2",
         "react-native-safe-area-context": "4.8.2",
@@ -32,15 +32,14 @@
       "devDependencies": {
         "@testing-library/jest-native": "5.4.2",
         "@testing-library/react-native": "12.4.1",
-        "@types/react": "18.2.37",
-        "@types/react-native": "0.73.0",
+        "@types/react": "~18.2.45",
         "@typescript-eslint/eslint-plugin": "6.7.4",
         "@typescript-eslint/parser": "6.7.4",
         "eslint": "8.53.0",
         "eslint-config-prettier": "9.1.0",
         "jest": "29.7.0",
-        "jest-expo": "50.0.2",
-        "typescript": "5.2.2"
+        "jest-expo": "~50.0.4",
+        "typescript": "^5.3.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2476,24 +2475,24 @@
       }
     },
     "node_modules/@expo/cli": {
-      "version": "0.17.5",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.17.5.tgz",
-      "integrity": "sha512-9cMquL/5bBfV73CbZcWipk3KZSo8mBqdgvkoWCtEtnnlm/879ayxzMWjVIgT5yV4w+X7+N6KkBSUIIj4t9Xqew==",
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.17.13.tgz",
+      "integrity": "sha512-n13yxOmI3I0JidzMdFCH68tYKGDtK4XlDFk1vysZX7AIRKeDVRsSbHhma5jCla2bDt25RKmJBHA9KtzielwzAA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/code-signing-certificates": "0.0.5",
         "@expo/config": "~8.5.0",
-        "@expo/config-plugins": "~7.8.0",
+        "@expo/config-plugins": "~7.9.0",
         "@expo/devcert": "^1.0.0",
-        "@expo/env": "~0.2.0",
+        "@expo/env": "~0.2.2",
         "@expo/image-utils": "^0.4.0",
         "@expo/json-file": "^8.2.37",
-        "@expo/metro-config": "~0.17.0",
+        "@expo/metro-config": "0.17.8",
         "@expo/osascript": "^2.0.31",
         "@expo/package-manager": "^1.1.1",
         "@expo/plist": "^0.1.0",
-        "@expo/prebuild-config": "6.7.4",
+        "@expo/prebuild-config": "6.8.1",
         "@expo/rudder-sdk-node": "1.1.1",
         "@expo/spawn-async": "1.5.0",
         "@expo/xcpretty": "^4.3.0",
@@ -2595,13 +2594,13 @@
       }
     },
     "node_modules/@expo/config": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-8.5.4.tgz",
-      "integrity": "sha512-ggOLJPHGzJSJHVBC1LzwXwR6qUn8Mw7hkc5zEKRIdhFRuIQ6s2FE4eOvP87LrNfDF7eZGa6tJQYsiHSmZKG+8Q==",
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-8.5.6.tgz",
+      "integrity": "sha512-wF5awSg6MNn1cb1lIgjnhOn5ov2TEUTnkAVCsOl0QqDwcP+YIerteSFwjn9V52UZvg58L+LKxpCuGbw5IHavbg==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "~7.10.4",
-        "@expo/config-plugins": "~7.8.2",
+        "@expo/config-plugins": "~7.9.0",
         "@expo/config-types": "^50.0.0",
         "@expo/json-file": "^8.2.37",
         "getenv": "^1.0.0",
@@ -2614,9 +2613,9 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-7.8.4.tgz",
-      "integrity": "sha512-hv03HYxb/5kX8Gxv/BTI8TLc9L06WzqAfHRRXdbar4zkLcP2oTzvsLEF4/L/TIpD3rsnYa0KU42d0gWRxzPCJg==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-7.9.2.tgz",
+      "integrity": "sha512-sRU/OAp7kJxrCUiCTUZqvPMKPdiN1oTmNfnbkG4oPdfWQTpid3jyCH7ZxJEN5SI6jrY/ZsK5B/JPgjDUhuWLBQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/config-types": "^50.0.0-alpha.1",
@@ -2963,9 +2962,9 @@
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.17.4.tgz",
-      "integrity": "sha512-PxqDMuVjXQeboa6Aj8kNj4iTxIpwpfoYlF803qOjf1LE1ePlREnWNwqy65ESCBnCmekYIO5hhm1Nksa+xCvuyg==",
+      "version": "0.17.8",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.17.8.tgz",
+      "integrity": "sha512-XNjI5Q5bW3k2ieNtQBSX9BnIysRxG4UyNsaWcysv3AzY+rahay6fAp5xzJey8xBOlzs9u7H4AdMoeJsUje3lcQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.0",
@@ -2973,7 +2972,7 @@
         "@babel/parser": "^7.20.0",
         "@babel/types": "^7.20.0",
         "@expo/config": "~8.5.0",
-        "@expo/env": "~0.2.0",
+        "@expo/env": "~0.2.2",
         "@expo/json-file": "~8.3.0",
         "@expo/spawn-async": "^1.7.2",
         "babel-preset-fbjs": "^3.4.0",
@@ -3156,13 +3155,13 @@
       }
     },
     "node_modules/@expo/prebuild-config": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-6.7.4.tgz",
-      "integrity": "sha512-x8EUdCa8DTMZ/dtEXjHAdlP+ljf6oSeSKNzhycXiHhpMSMG9jEhV28ocCwc6cKsjK5GziweEiHwvrj6+vsBlhA==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-6.8.1.tgz",
+      "integrity": "sha512-ptK9e0dcj1eYlAWV+fG+QkuAWcLAT1AmtEbj++tn7ZjEj8+LkXRM73LCOEGaF0Er8i8ZWNnaVsgGW4vjgP5ZsA==",
       "license": "MIT",
       "dependencies": {
         "@expo/config": "~8.5.0",
-        "@expo/config-plugins": "~7.8.0",
+        "@expo/config-plugins": "~7.9.0",
         "@expo/config-types": "^50.0.0-alpha.1",
         "@expo/image-utils": "^0.4.0",
         "@expo/json-file": "^8.2.37",
@@ -5907,34 +5906,15 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.2.37",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.37.tgz",
-      "integrity": "sha512-RGAYMi2bhRgEXT3f4B92WTohopH6bIXw05FuGlmJEnv/omEn190+QYEIYxIAuIBdKgboYYdVved2p1AxZVQnaw==",
+      "version": "18.2.79",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.79.tgz",
+      "integrity": "sha512-RwGAGXPl9kSXwdNTafkOEuFrTBD5SA2B3iEB96xi8+xu5ddUa/cpvyVCSNn+asgLCTHkb5ZxN8gbuibYJi4s1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
-    },
-    "node_modules/@types/react-native": {
-      "version": "0.73.0",
-      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.73.0.tgz",
-      "integrity": "sha512-6ZRPQrYM72qYKGWidEttRe6M5DZBEV5F+MHMHqd4TTYx0tfkcdrUFGdef6CCxY0jXU7wldvd/zA/b0A/kTeJmA==",
-      "deprecated": "This is a stub types definition. react-native provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "react-native": "*"
-      }
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-WFHp9YUJQ6CKshqoC37iOlHnQSmxNc795UhB26CyBBttrN9svdIrUjl/NjnNmfcwtncN0h/0PPAFWv9ovP8mLA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/semver": {
       "version": "7.7.1",
@@ -8945,24 +8925,24 @@
       }
     },
     "node_modules/expo": {
-      "version": "50.0.7",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-50.0.7.tgz",
-      "integrity": "sha512-lTqIrKOUTKHLdTuAaJzZihi1v7F8Ix1dOXVWMpToDy9zPC/s+fet0fbyXdFUxYsCUyuEDIB9tvejrTYZk8Hm0Q==",
+      "version": "50.0.21",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-50.0.21.tgz",
+      "integrity": "sha512-lY+HJdQcsTUbEtPhgT3Y2+WwKZdJiYN0Zq5yAOT9293N1TbdLbHCNkOUtFfTmK0JjwgSKbbH4kRlue7a4MJflg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "0.17.5",
-        "@expo/config": "8.5.4",
-        "@expo/config-plugins": "7.8.4",
-        "@expo/metro-config": "0.17.4",
+        "@expo/cli": "0.17.13",
+        "@expo/config": "8.5.6",
+        "@expo/config-plugins": "7.9.2",
+        "@expo/metro-config": "0.17.8",
         "@expo/vector-icons": "^14.0.0",
-        "babel-preset-expo": "~10.0.1",
+        "babel-preset-expo": "~10.0.2",
         "expo-asset": "~9.0.2",
-        "expo-file-system": "~16.0.6",
+        "expo-file-system": "~16.0.9",
         "expo-font": "~11.10.3",
         "expo-keep-awake": "~12.8.2",
         "expo-modules-autolinking": "1.10.3",
-        "expo-modules-core": "1.11.9",
+        "expo-modules-core": "1.11.14",
         "fbemitter": "^3.0.0",
         "whatwg-url-without-unicode": "8.0.0-3"
       },
@@ -9018,50 +8998,45 @@
       }
     },
     "node_modules/expo-image": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/expo-image/-/expo-image-2.4.0.tgz",
-      "integrity": "sha512-TQ/LvrtJ9JBr+Tf198CAqflxcvdhuj7P24n0LQ1jHaWIVA7Z+zYKbYHnSMPSDMul/y0U46Z5bFLbiZiSidgcNw==",
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/expo-image/-/expo-image-1.10.6.tgz",
+      "integrity": "sha512-vcnAIym1eU8vQgV1re1E7rVQZStJimBa4aPDhjFfzMzbddAF7heJuagyewiUkTzbZUwYzPaZAie6VJPyWx9Ueg==",
       "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
-        "react-native": "*",
-        "react-native-web": "*"
+      "dependencies": {
+        "@react-native/assets-registry": "~0.73.1"
       },
-      "peerDependenciesMeta": {
-        "react-native-web": {
-          "optional": true
-        }
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-image-loader": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.1.0.tgz",
-      "integrity": "sha512-sEBx3zDQIODWbB5JwzE7ZL5FJD+DK3LVLWBVJy6VzsqIA6nDEnSFnsnWyCfCTSvbGigMATs1lgkC2nz3Jpve1Q==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-4.6.0.tgz",
+      "integrity": "sha512-RHQTDak7/KyhWUxikn2yNzXL7i2cs16cMp6gEAgkHOjVhoCJQoOJ0Ljrt4cKQ3IowxgCuOrAgSUzGkqs7omj8Q==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
       }
     },
     "node_modules/expo-image-manipulator": {
-      "version": "13.1.7",
-      "resolved": "https://registry.npmjs.org/expo-image-manipulator/-/expo-image-manipulator-13.1.7.tgz",
-      "integrity": "sha512-DBy/Xdd0E/yFind14x36XmwfWuUxOHI/oH97/giKjjPaRc2dlyjQ3tuW3x699hX6gAs9Sixj5WEJ1qNf3c8sag==",
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/expo-image-manipulator/-/expo-image-manipulator-11.8.0.tgz",
+      "integrity": "sha512-ZWVrHnYmwJq6h7auk+ropsxcNi+LyZcPFKQc8oy+JA0SaJosfShvkCm7RADWAunHmfPCmjHrhwPGEu/rs7WG/A==",
       "license": "MIT",
       "dependencies": {
-        "expo-image-loader": "~5.1.0"
+        "expo-image-loader": "~4.6.0"
       },
       "peerDependencies": {
         "expo": "*"
       }
     },
     "node_modules/expo-image-picker": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.1.4.tgz",
-      "integrity": "sha512-bTmmxtw1AohUT+HxEBn2vYwdeOrj1CLpMXKjvi9FKSoSbpcarT4xxI0z7YyGwDGHbrJqyyic3I9TTdP2J2b4YA==",
+      "version": "14.7.1",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-14.7.1.tgz",
+      "integrity": "sha512-ILQVOJgI3aEzrDmCFGDPtpAepYkn8mot8G7vfQ51BfFdQbzL6N3Wm1fS/ofdWlAZJl/qT2DwaIh5xYmf3SyGZA==",
       "license": "MIT",
       "dependencies": {
-        "expo-image-loader": "~5.1.0"
+        "expo-image-loader": "~4.6.0"
       },
       "peerDependencies": {
         "expo": "*"
@@ -9130,9 +9105,9 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "1.11.9",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-1.11.9.tgz",
-      "integrity": "sha512-GTUb81vcPaF+5MtlBI1u9IjrZbGdF1ZUwz3u8Gc+rOLBblkZ7pYsj2mU/tu+k0khTckI9vcH4ZBksXWvE1ncjQ==",
+      "version": "1.11.14",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-1.11.14.tgz",
+      "integrity": "sha512-+W+A/jYJdWzA43KEAixhoArEb0EzTsS6T3tObYkZ1EHk8LaBT3hnFant52CnFTeVY4pqv4mgutBua2UQQMAWFA==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
@@ -11343,9 +11318,9 @@
       }
     },
     "node_modules/jest-expo": {
-      "version": "50.0.2",
-      "resolved": "https://registry.npmjs.org/jest-expo/-/jest-expo-50.0.2.tgz",
-      "integrity": "sha512-g9Vq4Cpndp6M+bWGNJfyxw+iiZm7o1XpaOEHgtyC1evdy4B9IsEWql1Y2xBH7uD79FwSKhaIz+xCQHZNhnSlAg==",
+      "version": "50.0.4",
+      "resolved": "https://registry.npmjs.org/jest-expo/-/jest-expo-50.0.4.tgz",
+      "integrity": "sha512-qtCqtdGaQtEcA3vc6UPN5Xn78jAyoBJj6Pxpk2raizdwI7carsg9Us9Wc+D4kl+7+ffhBMeS3cYWeJqVIZl1pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14687,9 +14662,9 @@
       }
     },
     "node_modules/react-native-maps": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.14.0.tgz",
-      "integrity": "sha512-ai7h4UdRLGPFCguz1fI8n4sKLEh35nZXHAH4nSWyAeHGrN8K9GjICu9Xd4Q5Ok4h+WwrM6Xz5pGbF3Qm1tO6iQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.10.0.tgz",
+      "integrity": "sha512-Zs6lHZucEijTwkRVFyInMbPVkJ2UudDEI2fJPc8ArdzdnwDFAdL6OagqTjNRZyI1DBPHRihazfIWpy2+X1VwLg==",
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.13"
@@ -16811,9 +16786,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -20,15 +20,15 @@
     "@tanstack/query-sync-storage-persister": "5.85.9",
     "@tanstack/react-query": "5.85.9",
     "@tanstack/react-query-persist-client": "5.85.9",
-    "expo": "50.0.7",
+    "expo": "~50.0.20",
     "expo-font": "11.10.3",
-    "expo-image": "2.4.0",
-    "expo-image-manipulator": "^13.1.7",
-    "expo-image-picker": "16.1.4",
+    "expo-image": "~1.10.6",
+    "expo-image-manipulator": "~11.8.0",
+    "expo-image-picker": "~14.7.1",
     "react": "18.2.0",
     "react-native": "0.73.6",
     "react-native-gesture-handler": "2.14.0",
-    "react-native-maps": "1.14.0",
+    "react-native-maps": "1.10.0",
     "react-native-mmkv": "2.10.2",
     "react-native-reanimated": "3.6.2",
     "react-native-safe-area-context": "4.8.2",
@@ -38,14 +38,13 @@
   "devDependencies": {
     "@testing-library/jest-native": "5.4.2",
     "@testing-library/react-native": "12.4.1",
-    "@types/react": "18.2.37",
-    "@types/react-native": "0.73.0",
+    "@types/react": "~18.2.45",
     "@typescript-eslint/eslint-plugin": "6.7.4",
     "@typescript-eslint/parser": "6.7.4",
     "eslint": "8.53.0",
     "eslint-config-prettier": "9.1.0",
     "jest": "29.7.0",
-    "jest-expo": "50.0.2",
-    "typescript": "5.2.2"
+    "jest-expo": "~50.0.4",
+    "typescript": "^5.3.0"
   }
 }

--- a/apps/mobile/scripts/expo-dep-guard.mjs
+++ b/apps/mobile/scripts/expo-dep-guard.mjs
@@ -12,21 +12,37 @@ function run(cmd, args, opts = {}) {
     process.exit(res.status ?? 1);
   }
 }
+
 function checkContains(file, needles) {
   const p = path.join(ROOT, file);
-  if (!existsSync(p)) { console.error(`[guard] Missing file: ${file}`); process.exit(1); }
+  if (!existsSync(p)) {
+    console.error(`[guard] Missing file: ${file}`);
+    process.exit(1);
+  }
   const s = readFileSync(p, 'utf8');
   for (const n of needles) {
-    if (!s.includes(n)) { console.error(`[guard] ${file} missing required snippet: ${n}`); process.exit(1); }
+    if (!s.includes(n)) {
+      console.error(`[guard] ${file} missing required snippet: ${n}`);
+      process.exit(1);
+    }
   }
 }
+
 console.log('\n[guard] Expo dependency alignment — start');
+run('node', ['scripts/fix-expo-versions.mjs']);
 run('npx', ['--yes', 'expo-doctor']);
 run('npx', ['expo', 'install', '--fix']);
 run('npx', ['expo', 'install', 'react-native-screens', 'react-native-safe-area-context']);
-checkContains('babel.config.js', ['babel-preset-expo','react-native-reanimated/plugin']);
-checkContains('metro.config.js', ['FORBIDDEN','disableHierarchicalLookup']);
+checkContains('babel.config.js', ['babel-preset-expo', 'react-native-reanimated/plugin']);
+checkContains('metro.config.js', ['expo/metro-config', 'FORBIDDEN', 'disableHierarchicalLookup']);
 checkContains('jest.config.js', ["preset: 'jest-expo'"]);
-checkContains('jest.setup.ts', ['NativeAnimatedHelper','react-native-reanimated','react-native-gesture-handler/jestSetup','react-native-screens','react-native-safe-area-context','PlatformConstants']);
+checkContains('jest.setup.ts', [
+  'NativeAnimatedHelper',
+  'react-native-reanimated',
+  'react-native-gesture-handler/jestSetup',
+  'react-native-screens',
+  'react-native-safe-area-context',
+  'PlatformConstants'
+]);
 if (os.platform() === 'darwin') run('npx', ['pod-install']);
 console.log('[guard] Expo dependency alignment — OK');

--- a/apps/mobile/scripts/fix-expo-versions.mjs
+++ b/apps/mobile/scripts/fix-expo-versions.mjs
@@ -1,0 +1,35 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+async function main() {
+  const pkgPath = path.join(ROOT, 'package.json');
+  const pkg = JSON.parse(await readFile(pkgPath, 'utf8'));
+
+  pkg.devDependencies = pkg.devDependencies ?? {};
+  delete pkg.devDependencies['@types/react-native'];
+  pkg.devDependencies['jest-expo'] = '~50.0.4';
+  pkg.devDependencies['typescript'] = '^5.3.0';
+  pkg.devDependencies['@types/react'] = '~18.2.45';
+
+  await writeFile(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+
+  await new Promise((resolve, reject) => {
+    const child = spawn('npx', ['expo', 'install', '--fix'], {
+      cwd: ROOT,
+      stdio: 'inherit'
+    });
+    child.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error('expo install --fix failed'));
+    });
+  });
+}
+
+main().catch((err) => {
+  console.error('[fix-expo-versions]', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- ensure Metro extends expo/metro-config with built-in guard and optional svg transformer
- add Expo version fixer and upgrade dep guard to enforce it
- bump mobile dev deps for Expo SDK 50 and drop @types/react-native

## Testing
- `npm run lint --prefix apps/mobile`
- `npm test --prefix apps/mobile`


------
https://chatgpt.com/codex/tasks/task_e_68b9a2636c50832fa98888a673595a39