### PR TITLE
feat: add marketing landing hero and header

### DIFF
--- a/apps/web/app/(marketing)/_styles.css
+++ b/apps/web/app/(marketing)/_styles.css
@@ -1,0 +1,16 @@
+@tailwind utilities;
+
+@layer utilities {
+  .label {
+    font-variant: small-caps;
+    @apply text-xs tracking-widest text-foreground opacity-70;
+  }
+
+  .heading-1 {
+    @apply text-[clamp(28px,4vw,40px)] font-extrabold leading-tight;
+  }
+
+  .text-muted {
+    @apply text-foreground opacity-70;
+  }
+}

--- a/apps/web/app/(marketing)/page.tsx
+++ b/apps/web/app/(marketing)/page.tsx
@@ -1,0 +1,16 @@
+import Header from '@/components/landing/Header';
+import Hero from '@/components/landing/Hero';
+import './_styles.css';
+
+export const dynamic = 'force-dynamic';
+
+export default function Page() {
+  return (
+    <>
+      <Header />
+      <main>
+        <Hero />
+      </main>
+    </>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,22 +1,2 @@
-'use client';
-
-import Image from 'next/image';
-import { useEffect, useState } from 'react';
-import { Button } from '../components/ui/button';
-import { getLatestNews } from '@thecueroom/ui';
-import type { NewsItem } from '@thecueroom/schemas';
-
-export default function Page() {
-  const [news, setNews] = useState<NewsItem[]>([]);
-  useEffect(() => {
-    getLatestNews('music').then(setNews).catch(() => setNews([]));
-  }, []);
-  return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-8 text-center">
-      <Image src="/landing.svg" alt="TheCueRoom landing hero" width={400} height={400} />
-      <h1 className="text-4xl font-bold">Welcome to TheCueRoom</h1>
-      {news[0] && <p className="text-sm text-foreground">{news[0].title}</p>}
-      <Button>Get Started</Button>
-    </main>
-  );
-}
+import Page from './(marketing)/page';
+export default Page;

--- a/apps/web/components/landing/Bloom.tsx
+++ b/apps/web/components/landing/Bloom.tsx
@@ -1,0 +1,10 @@
+export default function Bloom() {
+  return (
+    <div
+      className="pointer-events-none absolute inset-0 -z-10 flex items-center justify-center"
+      aria-hidden="true"
+    >
+      <div className="h-[400px] w-[400px] rounded-full bg-[radial-gradient(circle_at_center,#D1FF3D,#873BBF)] opacity-35 blur-[80px]" />
+    </div>
+  );
+}

--- a/apps/web/components/landing/Header.tsx
+++ b/apps/web/components/landing/Header.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+import Logo from '@/components/Logo';
+
+export default function Header() {
+  return (
+    <header className="py-6">
+      <div className="mx-auto flex max-w-[1200px] items-center justify-between px-6">
+        <Logo className="h-6 w-6" />
+        <Link
+          href="/login"
+          className="rounded bg-lime px-4 py-2 font-bold text-black"
+        >
+          Login / Sign Up
+        </Link>
+      </div>
+    </header>
+  );
+}

--- a/apps/web/components/landing/Hero.tsx
+++ b/apps/web/components/landing/Hero.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import Bloom from './Bloom';
+
+export default function Hero() {
+  const [showImage, setShowImage] = useState(true);
+
+  return (
+    <section className="relative mx-auto max-w-[1200px] px-6 py-24 text-center">
+      <Bloom />
+      <h1 className="heading-1">Welcome to thecueRoom</h1>
+      <p className="text-muted mx-auto mt-4 max-w-2xl">
+        Discover the next wave of underground music powered by community and tech.
+      </p>
+      <p className="mt-2 italic text-purple">
+        Where music meets machine, and the underground stays pure.
+      </p>
+      <div className="mt-8 flex items-center justify-center gap-4">
+        <Link
+          href="/signup"
+          className="rounded bg-lime px-6 py-3 font-bold text-black"
+        >
+          Join the Community
+        </Link>
+        <Link
+          href="#learn-more"
+          className="rounded border border-lime px-6 py-3 font-bold text-lime"
+        >
+          Learn More
+        </Link>
+      </div>
+      {showImage && (
+        <div className="mt-16">
+          <Image
+            src="/landing.svg"
+            alt="TheCueRoom landing illustration"
+            width={400}
+            height={300}
+            className="h-auto w-full"
+            onError={() => setShowImage(false)}
+            priority
+          />
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add marketing landing header and hero with bloom effect
- wire new landing page and scoped styles

## Testing
- `npm run lint:web`
- `npm run build:web`


------
https://chatgpt.com/codex/tasks/task_e_68b9ce0e7528832f956e232f6a61ce52