### PR TITLE
feat: add marketing landing sections and footer

### DIFF
--- a/apps/web/app/(marketing)/page.tsx
+++ b/apps/web/app/(marketing)/page.tsx
@@ -1,5 +1,10 @@
 import Header from '@/components/landing/Header';
 import Hero from '@/components/landing/Hero';
+import FeatureGrid from '@/components/landing/FeatureGrid';
+import FeedPreview from '@/components/landing/FeedPreview';
+import HowItWorks from '@/components/landing/HowItWorks';
+import CtaBand from '@/components/landing/CtaBand';
+import Footer from '@/components/landing/Footer';
 import './_styles.css';
 
 export const dynamic = 'force-dynamic';
@@ -10,7 +15,14 @@ export default function Page() {
       <Header />
       <main>
         <Hero />
+        <FeatureGrid />
+        <div className="mx-auto max-w-[1200px] px-6 py-24 md:grid md:grid-cols-2 md:gap-8">
+          <FeedPreview />
+          <HowItWorks />
+        </div>
+        <CtaBand />
       </main>
+      <Footer />
     </>
   );
 }

--- a/apps/web/components/landing/Card.tsx
+++ b/apps/web/components/landing/Card.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+
+interface CardProps {
+  title: string;
+  body: ReactNode;
+}
+
+export default function Card({ title, body }: CardProps) {
+  return (
+    <div className="rounded-md bg-surface p-4 border border-white/10">
+      <h3 className="text-sm font-semibold">{title}</h3>
+      <p className="mt-1 text-xs text-muted">{body}</p>
+    </div>
+  );
+}

--- a/apps/web/components/landing/CtaBand.tsx
+++ b/apps/web/components/landing/CtaBand.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+
+export default function CtaBand() {
+  return (
+    <section className="mx-auto max-w-[1200px] px-6 py-24" aria-labelledby="cta-heading">
+      <div className="rounded-md bg-surface p-8 text-center border border-white/10">
+        <h2 id="cta-heading" className="text-2xl font-bold">
+          Ready to dive in?
+        </h2>
+        <p className="mt-2 text-muted">
+          Join the community or learn more about our platform.
+        </p>
+        <div className="mt-6 flex justify-center gap-4">
+          <Link
+            href="/signup"
+            className="rounded bg-lime px-6 py-3 font-bold text-black"
+          >
+            Join the Community
+          </Link>
+          <Link
+            href="#learn-more"
+            className="rounded border border-lime px-6 py-3 font-bold text-lime"
+          >
+            Learn More
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/landing/FeatureGrid.tsx
+++ b/apps/web/components/landing/FeatureGrid.tsx
@@ -1,0 +1,47 @@
+import Card from './Card';
+
+const features = [
+  {
+    title: 'Curated Community',
+    body: 'Join a vetted network of underground artists and fans.',
+  },
+  {
+    title: 'Real-Time Feed',
+    body: 'Stay updated with the latest drops and discussions.',
+  },
+  {
+    title: 'Event Radar',
+    body: 'Discover gigs and meetups tailored to your taste.',
+  },
+  {
+    title: 'Collaborative Playlists',
+    body: 'Build and share mixes with the community.',
+  },
+  {
+    title: 'AI Tools',
+    body: 'Leverage machine learning to surface hidden gems.',
+  },
+  {
+    title: 'Secure Profiles',
+    body: 'Own your identity with privacy-first accounts.',
+  },
+];
+
+export default function FeatureGrid() {
+  return (
+    <section
+      id="learn-more"
+      className="mx-auto max-w-[1200px] px-6 py-24"
+      aria-labelledby="features-heading"
+    >
+      <p id="features-heading" className="label mb-6">
+        What you get
+      </p>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {features.map((feature) => (
+          <Card key={feature.title} title={feature.title} body={feature.body} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/landing/FeedPreview.tsx
+++ b/apps/web/components/landing/FeedPreview.tsx
@@ -1,0 +1,26 @@
+const lines = [
+  'Members share underground finds daily.',
+  'Vote and comment to surface the best.',
+  'Follow threads from your favorite creators.',
+];
+
+export default function FeedPreview() {
+  return (
+    <section
+      className="rounded-md bg-surface p-6 border border-white/10"
+      aria-labelledby="feed-preview-heading"
+    >
+      <h2 id="feed-preview-heading" className="mb-4 text-base font-semibold">
+        Community Feed Preview
+      </h2>
+      <ul className="space-y-2">
+        {lines.map((line) => (
+          <li key={line} className="flex items-start gap-2">
+            <span className="mt-1 h-2 w-2 flex-none bg-lime" />
+            <span className="text-sm text-muted">{line}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/components/landing/Footer.tsx
+++ b/apps/web/components/landing/Footer.tsx
@@ -1,0 +1,63 @@
+import Link from 'next/link';
+
+const columns = [
+  {
+    title: 'Product',
+    links: [
+      { label: 'Features', href: '#' },
+      { label: 'Pricing', href: '#' },
+    ],
+  },
+  {
+    title: 'Community',
+    links: [
+      { label: 'Feed', href: '/feed' },
+      { label: 'Discord', href: '#' },
+    ],
+  },
+  {
+    title: 'Legal',
+    links: [
+      { label: 'Terms', href: '#' },
+      { label: 'Privacy', href: '#' },
+    ],
+  },
+  {
+    title: 'Social',
+    links: [
+      { label: 'Twitter', href: '#' },
+      { label: 'Instagram', href: '#' },
+    ],
+  },
+];
+
+export default function Footer() {
+  return (
+    <footer className="bg-background" aria-labelledby="footer-heading">
+      <div className="mx-auto flex max-w-[1200px] flex-col items-start justify-between gap-8 px-6 py-12 md:flex-row">
+        <p className="text-xs text-muted">
+          © TheCueRoom {new Date().getFullYear()} – All rights reserved.
+        </p>
+        <nav aria-labelledby="footer-heading" className="grid flex-1 grid-cols-2 gap-8 sm:grid-cols-4">
+          {columns.map((col) => (
+            <div key={col.title}>
+              <h3 className="text-sm font-semibold">{col.title}</h3>
+              <ul className="mt-4 space-y-2">
+                {col.links.map((link) => (
+                  <li key={link.label}>
+                    <Link
+                      href={link.href}
+                      className="text-sm text-muted hover:text-lime hover:underline focus-visible:text-lime focus-visible:underline"
+                    >
+                      {link.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/apps/web/components/landing/HowItWorks.tsx
+++ b/apps/web/components/landing/HowItWorks.tsx
@@ -1,0 +1,21 @@
+const steps = [
+  'Sign up and create your profile.',
+  'Explore the feed and follow creators.',
+  'Share your finds and join discussions.',
+  'Attend events and grow your network.',
+];
+
+export default function HowItWorks() {
+  return (
+    <section aria-labelledby="how-it-works-heading">
+      <h2 id="how-it-works-heading" className="mb-4 text-base font-semibold">
+        How TheCueRoom Works
+      </h2>
+      <ul className="list-disc space-y-2 pl-5 text-sm text-muted marker:text-lime">
+        {steps.map((step) => (
+          <li key={step}>{step}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add card, feature grid, feed preview, how-it-works, CTA band, and footer components
- compose new sections in marketing landing page

## Testing
- `npm run lint:web`
- `npm run build:web`


------
https://chatgpt.com/codex/tasks/task_e_68b9dc6a97dc832fbee09dcd2527d6bd