### PR TITLE
feat(web): finalize landing sections

### DIFF
--- a/apps/web/components/landing/Card.tsx
+++ b/apps/web/components/landing/Card.tsx
@@ -7,7 +7,7 @@ interface CardProps {
 
 export default function Card({ title, body }: CardProps) {
   return (
-    <div className="rounded-md bg-surface p-4 border border-white/10">
+    <div className="rounded-md bg-surface p-4 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)]">
       <h3 className="text-sm font-semibold">{title}</h3>
       <p className="mt-1 text-xs text-muted">{body}</p>
     </div>

--- a/apps/web/components/landing/CtaBand.tsx
+++ b/apps/web/components/landing/CtaBand.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 export default function CtaBand() {
   return (
     <section className="mx-auto max-w-[1200px] px-6 py-24" aria-labelledby="cta-heading">
-      <div className="rounded-md bg-surface p-8 text-center border border-white/10">
+      <div className="rounded-md bg-surface p-8 text-center shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)]">
         <h2 id="cta-heading" className="text-2xl font-bold">
           Ready to dive in?
         </h2>
@@ -13,13 +13,13 @@ export default function CtaBand() {
         <div className="mt-6 flex justify-center gap-4">
           <Link
             href="/signup"
-            className="rounded bg-lime px-6 py-3 font-bold text-black"
+            className="rounded bg-lime px-6 py-3 font-bold text-black focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lime"
           >
             Join the Community
           </Link>
           <Link
             href="#learn-more"
-            className="rounded border border-lime px-6 py-3 font-bold text-lime"
+            className="rounded border border-lime px-6 py-3 font-bold text-lime focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lime"
           >
             Learn More
           </Link>

--- a/apps/web/components/landing/FeedPreview.tsx
+++ b/apps/web/components/landing/FeedPreview.tsx
@@ -7,7 +7,7 @@ const lines = [
 export default function FeedPreview() {
   return (
     <section
-      className="rounded-md bg-surface p-6 border border-white/10"
+      className="rounded-md bg-surface p-6 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)]"
       aria-labelledby="feed-preview-heading"
     >
       <h2 id="feed-preview-heading" className="mb-4 text-base font-semibold">

--- a/apps/web/components/landing/Footer.tsx
+++ b/apps/web/components/landing/Footer.tsx
@@ -34,11 +34,14 @@ const columns = [
 export default function Footer() {
   return (
     <footer className="bg-background" aria-labelledby="footer-heading">
+      <h2 id="footer-heading" className="sr-only">
+        Footer
+      </h2>
       <div className="mx-auto flex max-w-[1200px] flex-col items-start justify-between gap-8 px-6 py-12 md:flex-row">
         <p className="text-xs text-muted">
           © TheCueRoom {new Date().getFullYear()} – All rights reserved.
         </p>
-        <nav aria-labelledby="footer-heading" className="grid flex-1 grid-cols-2 gap-8 sm:grid-cols-4">
+        <nav className="grid flex-1 grid-cols-2 gap-8 sm:grid-cols-4">
           {columns.map((col) => (
             <div key={col.title}>
               <h3 className="text-sm font-semibold">{col.title}</h3>
@@ -47,7 +50,7 @@ export default function Footer() {
                   <li key={link.label}>
                     <Link
                       href={link.href}
-                      className="text-sm text-muted hover:text-lime hover:underline focus-visible:text-lime focus-visible:underline"
+                      className="text-sm text-muted hover:text-lime hover:underline focus-visible:text-lime focus-visible:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lime"
                     >
                       {link.label}
                     </Link>


### PR DESCRIPTION
## Summary
- style landing feature cards and feed preview with inset borders for dark theme
- add accessible CTA band with focus-visible outlines
- polish footer with hidden heading and stronger link focus states

## Testing
- `npm run lint:web`
- `npm run build:web`


------
https://chatgpt.com/codex/tasks/task_e_68b9dfb9bfc8832fbdd760e820547f1d