### PR TITLE
feat: add landing snapshot test

### DIFF
--- a/apps/web/e2e/landing.spec.ts
+++ b/apps/web/e2e/landing.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+import fs from 'node:fs';
+
+// Visual regression for marketing landing page
+// Ensures baseline screenshot at docs/assets/MarketingLanding.reference.png
+
+test('marketing landing matches baseline', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => document.fonts.ready);
+  await page.addStyleTag({
+    content: `
+      *,*::before,*::after{transition:none!important;animation:none!important;}
+      html{scroll-behavior:auto!important;}
+    `
+  });
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  const screenshot = await page.screenshot();
+  const baseline = fs.readFileSync(
+    new URL('../../../docs/assets/MarketingLanding.reference.png', import.meta.url)
+  );
+  await expect(screenshot).toMatchSnapshot(baseline, {
+    maxDiffPixelRatio: 0.03
+  });
+});

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -2,9 +2,12 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './e2e',
-  use: { baseURL: 'http://localhost:3000' },
+  use: {
+    baseURL: 'http://localhost:3000',
+    viewport: { width: 1440, height: 1024 }
+  },
   webServer: {
-    command: 'npm run build && npm run start',
+    command: 'npm run dev',
     port: 3000,
     reuseExistingServer: !process.env.CI
   }

--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -1,0 +1,12 @@
+# Visual baselines
+
+`MarketingLanding.reference.png` stores the reference snapshot for the marketing landing page test located at `apps/web/e2e/landing.spec.ts`.
+
+## Update the baseline
+
+Run the Playwright test with the `--update-snapshots` flag after intentional UI changes:
+
+```bash
+cd apps/web
+npm run e2e -- --update-snapshots
+```


### PR DESCRIPTION
## Summary
- configure Playwright for 1440x1024 viewport and dev server
- add landing page visual regression test against stored baseline
- document snapshot location and update instructions

## Testing
- `npm run build`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68b9e1ad3320832f910d19cd543483d9