### PR TITLE
feat(web): add seo metadata and pwa assets

### DIFF
--- a/apps/web/app/admin/AdminClient.tsx
+++ b/apps/web/app/admin/AdminClient.tsx
@@ -15,7 +15,7 @@ export default function AdminClient({ initialArtists }: { initialArtists: Artist
           <li key={a.id} className="flex items-center justify-between">
             <span>{a.name}</span>
             <button
-              className="rounded bg-green-500 px-2 py-1 text-sm text-white"
+              className="h-8 rounded bg-green-500 px-2 text-sm text-white"
               onClick={() => setList((l) => l.filter((x) => x.id !== a.id))}
             >
               Verify

--- a/apps/web/app/icon.svg
+++ b/apps/web/app/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="#D1FF3D">
+  <circle cx="16" cy="16" r="16" />
+</svg>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,13 +1,27 @@
 import './globals.css';
 import { Inter, Source_Code_Pro } from 'next/font/google';
+import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-sans', display: 'swap' });
 const mono = Source_Code_Pro({ subsets: ['latin'], variable: '--font-mono', display: 'swap' });
 
+export const metadata: Metadata = {
+  metadataBase: new URL('https://thecueroom.com'),
+  title: 'TheCueRoom',
+  description:
+    'Discover the next wave of underground music powered by community and tech.',
+};
+
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className="dark">
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+        <link rel="manifest" href="/manifest.webmanifest" />
+        <link rel="icon" href="/icon.svg" type="image/svg+xml" />
+      </head>
       <body className={`${inter.variable} ${mono.variable} bg-background text-white`}>
         {children}
       </body>

--- a/apps/web/app/manifest.webmanifest
+++ b/apps/web/app/manifest.webmanifest
@@ -1,0 +1,16 @@
+{
+  "name": "TheCueRoom",
+  "short_name": "CueRoom",
+  "description": "Discover the next wave of underground music powered by community and tech.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0B0B0B",
+  "theme_color": "#D1FF3D",
+  "icons": [
+    {
+      "src": "/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/apps/web/app/opengraph-image.tsx
+++ b/apps/web/app/opengraph-image.tsx
@@ -1,0 +1,31 @@
+import { ImageResponse } from 'next/og';
+
+export const size = {
+  width: 1200,
+  height: 630
+};
+
+export const contentType = 'image/png';
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          backgroundColor: '#0B0B0B',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: '#D1FF3D',
+          fontSize: 72,
+          fontFamily: 'Inter, sans-serif'
+        }}
+      >
+        TheCueRoom
+      </div>
+    ),
+    size
+  );
+}

--- a/apps/web/app/profile/[handle]/ProfileClient.tsx
+++ b/apps/web/app/profile/[handle]/ProfileClient.tsx
@@ -16,13 +16,13 @@ export default function ProfileClient({ profile }: { profile: Profile }) {
       <h1 className="mb-4 text-2xl font-bold">@{profile.handle}</h1>
       <div className="mb-4 flex gap-4 border-b pb-2">
         <button
-          className={tab === 'posts' ? 'font-semibold' : ''}
+          className={`${tab === 'posts' ? 'font-semibold' : ''} h-8 px-2`}
           onClick={() => setTab('posts')}
         >
           Posts
         </button>
         <button
-          className={tab === 'about' ? 'font-semibold' : ''}
+          className={`${tab === 'about' ? 'font-semibold' : ''} h-8 px-2`}
           onClick={() => setTab('about')}
         >
           About

--- a/apps/web/app/robots.txt
+++ b/apps/web/app/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://thecueroom.com/sitemap.xml

--- a/apps/web/components/CommentList.tsx
+++ b/apps/web/components/CommentList.tsx
@@ -34,7 +34,7 @@ export default function CommentList({
           value={text}
           onChange={(e) => setText(e.target.value)}
         />
-        <button type="submit" className="rounded bg-blue-500 px-2 py-1 text-sm text-white">
+        <button type="submit" className="h-8 rounded bg-blue-500 px-2 text-sm text-white">
           Post
         </button>
       </form>

--- a/apps/web/components/ReactionBar.tsx
+++ b/apps/web/components/ReactionBar.tsx
@@ -12,7 +12,7 @@ export default function ReactionBar({ initialLikes = 0 }: { initialLikes?: numbe
       <button
         type="button"
         aria-label="like"
-        className="rounded bg-gray-200 px-2 py-1 text-sm"
+        className="flex h-8 items-center rounded bg-gray-200 px-2 text-sm"
         onClick={() => setLikes((l) => l + 1)}
       >
         👍 {likes}

--- a/apps/web/components/landing/Hero.tsx
+++ b/apps/web/components/landing/Hero.tsx
@@ -21,13 +21,13 @@ export default function Hero() {
       <div className="mt-8 flex items-center justify-center gap-4">
         <Link
           href="/signup"
-          className="rounded bg-lime px-6 py-3 font-bold text-black"
+          className="flex h-11 items-center rounded bg-lime px-6 font-bold text-black"
         >
           Join the Community
         </Link>
         <Link
           href="#learn-more"
-          className="rounded border border-lime px-6 py-3 font-bold text-lime"
+          className="flex h-11 items-center rounded border border-lime px-6 font-bold text-lime"
         >
           Learn More
         </Link>

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,7 +1,13 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  transpilePackages: ['@thecueroom/ui', '@thecueroom/schemas']
+  transpilePackages: ['@thecueroom/ui', '@thecueroom/schemas'],
+  outputFileTracingRoot: path.resolve(__dirname, '../../')
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- add site metadata with font preconnect and PWA links
- introduce robots.txt, manifest, OG image, and lime icon
- fix button heights to avoid CLS and silence build warnings

## Testing
- `npm run lint:web`
- `npm run build:web`


------
https://chatgpt.com/codex/tasks/task_e_68b9ea4dbd58832fbd0d7042c99bcf07