### PR TITLE
feat: add shared schemas, db, and supabase wiring

### DIFF
--- a/apps/mobile/src/lib/supabase.ts
+++ b/apps/mobile/src/lib/supabase.ts
@@ -1,11 +1,16 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL ?? 'http://localhost';
-const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? 'anon';
+const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Supabase env vars missing');
+}
+
+export const supabase: SupabaseClient = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {
     persistSession: true,
-    detectSessionInUrl: false,
-  },
+    detectSessionInUrl: false
+  }
 });
+export type { SupabaseClient } from '@supabase/supabase-js';

--- a/apps/web/lib/supabase-browser.ts
+++ b/apps/web/lib/supabase-browser.ts
@@ -1,17 +1,21 @@
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
 let client: SupabaseClient | null = null;
 
-export function getBrowserClient() {
-  if (client) return client;
+export function createBrowserClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   if (!url || !anonKey) {
     throw new Error('Supabase env vars missing');
   }
-  client = createClient(url, anonKey, {
-    auth: { persistSession: false }
-  });
+  return createClient(url, anonKey, { auth: { persistSession: false } });
+}
+
+export function getBrowserClient() {
+  if (!client) {
+    client = createBrowserClient();
+  }
   return client;
 }
+
 export type { SupabaseClient } from '@supabase/supabase-js';

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -31,3 +31,10 @@ eas submit --profile production --platform ios
 eas submit --profile production --platform android
 cd ../..
 ```
+
+## Apply database migrations
+```bash
+# from repo root
+DRIZZLE_DATABASE_URL="postgres://user:pass@host:5432/db" npx drizzle-kit push:pg --config=packages/db/drizzle.config.ts
+psql "$DRIZZLE_DATABASE_URL" -f supabase/sql/rls_policies.sql
+```

--- a/packages/db/.env.example
+++ b/packages/db/.env.example
@@ -1,1 +1,2 @@
-DRIZZLE_DATABASE_URL=
+# Connection string for drizzle migrations
+DRIZZLE_DATABASE_URL=postgres://user:password@localhost:5432/postgres

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -2,8 +2,14 @@
 
 Drizzle ORM schema and migrations for TheCueRoom.
 
-## Development
+## Migrations
 
 ```bash
+# generate a new migration
 npx drizzle-kit generate:pg --config=packages/db/drizzle.config.ts
+
+# push schema to Supabase
+DRIZZLE_DATABASE_URL="postgres://user:pass@host:5432/db" npx drizzle-kit push:pg --config=packages/db/drizzle.config.ts
+psql "$DRIZZLE_DATABASE_URL" -f supabase/sql/rls_policies.sql
 ```
+

--- a/packages/db/migrations/000_init.sql
+++ b/packages/db/migrations/000_init.sql
@@ -1,0 +1,148 @@
+-- Initial schema for TheCueRoom
+
+-- Enums
+create type if not exists role_enum as enum ('pending','verified','moderator','admin');
+create type if not exists verification_enum as enum ('pending','verified','rejected','needs_info');
+create type if not exists reaction_kind_enum as enum ('heart','fire','alien','bolt');
+
+-- Tables
+create table if not exists users (
+  id uuid primary key default gen_random_uuid(),
+  email text,
+  created_at timestamptz default now()
+);
+
+create table if not exists profiles (
+  user_id uuid primary key references users(id),
+  handle text unique not null,
+  display_name text,
+  bio text,
+  avatar_url text,
+  role role_enum not null default 'pending',
+  verification verification_enum not null default 'pending',
+  is_admin boolean not null default false
+);
+
+create table if not exists posts (
+  id uuid primary key default gen_random_uuid(),
+  author_id uuid references profiles(user_id),
+  body text not null,
+  media_url text,
+  visibility text not null default 'public',
+  created_at timestamptz not null default now()
+);
+
+create table if not exists comments (
+  id uuid primary key default gen_random_uuid(),
+  post_id uuid references posts(id),
+  author_id uuid references profiles(user_id),
+  body text not null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists reactions (
+  id uuid primary key default gen_random_uuid(),
+  post_id uuid references posts(id),
+  comment_id uuid references comments(id),
+  user_id uuid references profiles(user_id),
+  kind reaction_kind_enum not null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists memes (
+  id uuid primary key default gen_random_uuid(),
+  author_id uuid references profiles(user_id),
+  prompt text not null,
+  image_url text not null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists playlists (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  description text,
+  spotify_url text,
+  order_index int default 0,
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists tracks (
+  id uuid primary key default gen_random_uuid(),
+  playlist_id uuid references playlists(id),
+  title text not null,
+  artist text not null,
+  spotify_url text,
+  position int not null
+);
+
+create table if not exists gigs (
+  id uuid primary key default gen_random_uuid(),
+  artist_id uuid references profiles(user_id),
+  city text not null,
+  venue text not null,
+  starts_at timestamptz not null,
+  lineup text,
+  ticket_url text
+);
+
+create table if not exists news (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  url text unique not null,
+  source text,
+  category text,
+  region text,
+  published_at timestamptz,
+  inserted_at timestamptz not null default now()
+);
+
+create table if not exists reports (
+  id uuid primary key default gen_random_uuid(),
+  target_type text not null,
+  target_id uuid not null,
+  reason text,
+  evidence jsonb,
+  reporter_id uuid references profiles(user_id),
+  created_at timestamptz not null default now()
+);
+
+create table if not exists notification_prefs (
+  user_id uuid primary key references profiles(user_id),
+  mentions boolean not null default true,
+  reactions boolean not null default true,
+  gigs boolean not null default true,
+  playlists boolean not null default true,
+  news jsonb not null default '{}'::jsonb
+);
+
+create table if not exists saved_items (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references profiles(user_id),
+  type text not null,
+  ref_id uuid not null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists messages (
+  id uuid primary key default gen_random_uuid(),
+  convo_id uuid not null,
+  sender_id uuid references profiles(user_id),
+  body text not null,
+  created_at timestamptz not null default now()
+);
+
+-- View
+create or replace view post_scores as
+  select
+    p.id as post_id,
+    ln(1 + coalesce(r.cnt,0)) * 0.6 +
+    ln(1 + coalesce(c.cnt,0)) * 0.4 +
+    1 / (1 + extract(epoch from (now() - p.created_at)) / 3600) as score
+  from posts p
+  left join (
+    select post_id, count(*) as cnt from reactions group by post_id
+  ) r on r.post_id = p.id
+  left join (
+    select post_id, count(*) as cnt from comments group by post_id
+  ) c on c.post_id = p.id;
+

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -5,62 +5,80 @@ import {
   text,
   timestamp,
   boolean,
+  jsonb,
+  integer,
+  pgView,
+  doublePrecision
 } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
 
-export const roleEnum = pgEnum('role', ['pending', 'verified', 'moderator', 'admin']);
-export const verificationStatusEnum = pgEnum('verification_status', ['unverified', 'pending', 'verified']);
-export const reactionEnum = pgEnum('reaction_type', ['❤️', '🔥', '👽', '⚡']);
+export const roleEnum = pgEnum('role_enum', ['pending', 'verified', 'moderator', 'admin']);
+export const verificationEnum = pgEnum('verification_enum', [
+  'pending',
+  'verified',
+  'rejected',
+  'needs_info'
+]);
+export const reactionKindEnum = pgEnum('reaction_kind_enum', ['heart', 'fire', 'alien', 'bolt']);
 
 export const users = pgTable('users', {
   id: uuid('id').primaryKey().defaultRandom(),
-  email: text('email').notNull().unique(),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
+  email: text('email'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
 });
 
 export const profiles = pgTable('profiles', {
-  id: uuid('id').primaryKey().references(() => users.id),
+  userId: uuid('user_id').primaryKey().references(() => users.id),
   handle: text('handle').notNull().unique(),
-  role: roleEnum('role').default('pending').notNull(),
-  verificationStatus: verificationStatusEnum('verification_status').default('unverified').notNull(),
+  displayName: text('display_name'),
+  bio: text('bio'),
+  avatarUrl: text('avatar_url'),
+  role: roleEnum('role').notNull().default('pending'),
+  verification: verificationEnum('verification').notNull().default('pending'),
+  isAdmin: boolean('is_admin').notNull().default(false)
 });
 
 export const posts = pgTable('posts', {
   id: uuid('id').primaryKey().defaultRandom(),
-  authorId: uuid('author_id').references(() => profiles.id).notNull(),
-  content: text('content').notNull(),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
+  authorId: uuid('author_id').references(() => profiles.userId).notNull(),
+  body: text('body').notNull(),
+  mediaUrl: text('media_url'),
+  visibility: text('visibility').notNull().default('public'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
 });
 
 export const comments = pgTable('comments', {
   id: uuid('id').primaryKey().defaultRandom(),
   postId: uuid('post_id').references(() => posts.id).notNull(),
-  authorId: uuid('author_id').references(() => profiles.id).notNull(),
-  content: text('content').notNull(),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
+  authorId: uuid('author_id').references(() => profiles.userId).notNull(),
+  body: text('body').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
 });
 
 export const reactions = pgTable('reactions', {
   id: uuid('id').primaryKey().defaultRandom(),
-  postId: uuid('post_id').references(() => posts.id).notNull(),
-  userId: uuid('user_id').references(() => users.id).notNull(),
-  type: reactionEnum('type').notNull(),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
+  postId: uuid('post_id').references(() => posts.id),
+  commentId: uuid('comment_id').references(() => comments.id),
+  userId: uuid('user_id').references(() => profiles.userId).notNull(),
+  kind: reactionKindEnum('kind').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
 });
 
 export const memes = pgTable('memes', {
   id: uuid('id').primaryKey().defaultRandom(),
-  authorId: uuid('author_id').references(() => profiles.id).notNull(),
+  authorId: uuid('author_id').references(() => profiles.userId).notNull(),
+  prompt: text('prompt').notNull(),
   imageUrl: text('image_url').notNull(),
-  caption: text('caption'),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
 });
 
 export const playlists = pgTable('playlists', {
   id: uuid('id').primaryKey().defaultRandom(),
-  ownerId: uuid('owner_id').references(() => profiles.id).notNull(),
   title: text('title').notNull(),
   description: text('description'),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
+  spotifyUrl: text('spotify_url'),
+  orderIndex: integer('order_index').notNull().default(0),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull()
 });
 
 export const tracks = pgTable('tracks', {
@@ -68,52 +86,81 @@ export const tracks = pgTable('tracks', {
   playlistId: uuid('playlist_id').references(() => playlists.id).notNull(),
   title: text('title').notNull(),
   artist: text('artist').notNull(),
-  url: text('url').notNull(),
+  spotifyUrl: text('spotify_url'),
+  position: integer('position').notNull()
 });
 
 export const gigs = pgTable('gigs', {
   id: uuid('id').primaryKey().defaultRandom(),
-  title: text('title').notNull(),
-  location: text('location').notNull(),
-  gigDate: timestamp('gig_date').notNull(),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
+  artistId: uuid('artist_id').references(() => profiles.userId).notNull(),
+  city: text('city').notNull(),
+  venue: text('venue').notNull(),
+  startsAt: timestamp('starts_at', { withTimezone: true }).notNull(),
+  lineup: text('lineup'),
+  ticketUrl: text('ticket_url')
 });
 
 export const news = pgTable('news', {
   id: uuid('id').primaryKey().defaultRandom(),
   title: text('title').notNull(),
-  url: text('url').notNull(),
-  summary: text('summary'),
-  publishedAt: timestamp('published_at').defaultNow().notNull(),
+  url: text('url').notNull().unique(),
+  source: text('source'),
+  category: text('category'),
+  region: text('region'),
+  publishedAt: timestamp('published_at', { withTimezone: true }),
+  insertedAt: timestamp('inserted_at', { withTimezone: true }).defaultNow().notNull()
 });
 
 export const reports = pgTable('reports', {
   id: uuid('id').primaryKey().defaultRandom(),
-  reporterId: uuid('reporter_id').references(() => users.id).notNull(),
   targetType: text('target_type').notNull(),
   targetId: uuid('target_id').notNull(),
   reason: text('reason'),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
+  evidence: jsonb('evidence'),
+  reporterId: uuid('reporter_id').references(() => profiles.userId).notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
 });
 
-export const notificationsPrefs = pgTable('notifications_prefs', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  userId: uuid('user_id').references(() => users.id).notNull(),
-  email: boolean('email').default(true).notNull(),
+export const notificationPrefs = pgTable('notification_prefs', {
+  userId: uuid('user_id').primaryKey().references(() => profiles.userId),
+  mentions: boolean('mentions').notNull().default(true),
+  reactions: boolean('reactions').notNull().default(true),
+  gigs: boolean('gigs').notNull().default(true),
+  playlists: boolean('playlists').notNull().default(true),
+  news: jsonb('news').notNull().default(sql`'{}'::jsonb`)
 });
 
 export const savedItems = pgTable('saved_items', {
   id: uuid('id').primaryKey().defaultRandom(),
-  userId: uuid('user_id').references(() => users.id).notNull(),
-  itemType: text('item_type').notNull(),
-  itemId: uuid('item_id').notNull(),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
+  userId: uuid('user_id').references(() => profiles.userId).notNull(),
+  type: text('type').notNull(),
+  refId: uuid('ref_id').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
 });
 
 export const messages = pgTable('messages', {
   id: uuid('id').primaryKey().defaultRandom(),
-  senderId: uuid('sender_id').references(() => users.id).notNull(),
-  receiverId: uuid('receiver_id').references(() => users.id).notNull(),
-  content: text('content').notNull(),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
+  convoId: uuid('convo_id').notNull(),
+  senderId: uuid('sender_id').references(() => profiles.userId).notNull(),
+  body: text('body').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
 });
+
+export const postScores = pgView('post_scores', {
+  postId: uuid('post_id'),
+  score: doublePrecision('score')
+}).as(sql`
+  select
+    p.id as post_id,
+    ln(1 + coalesce(r.cnt, 0)) * 0.6 +
+    ln(1 + coalesce(c.cnt, 0)) * 0.4 +
+    1 / (1 + extract(epoch from (now() - p.created_at)) / 3600) as score
+  from posts p
+  left join (
+    select post_id, count(*) as cnt from reactions group by post_id
+  ) r on r.post_id = p.id
+  left join (
+    select post_id, count(*) as cnt from comments group by post_id
+  ) c on c.post_id = p.id
+`);
+

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -1,22 +1,33 @@
 import { z } from 'zod';
 
 export const roleEnum = z.enum(['pending', 'verified', 'moderator', 'admin']);
-export const verificationStatusEnum = z.enum(['unverified', 'pending', 'verified']);
-export const reactionEnum = z.enum(['❤️', '🔥', '👽', '⚡']);
+export const verificationEnum = z.enum([
+  'pending',
+  'verified',
+  'rejected',
+  'needs_info'
+]);
+export const reactionKindEnum = z.enum(['heart', 'fire', 'alien', 'bolt']);
 
 export const userProfileSchema = z.object({
   id: z.string().uuid(),
   handle: z.string().min(3),
+  displayName: z.string(),
+  bio: z.string().optional(),
   role: roleEnum,
-  verificationStatus: verificationStatusEnum,
+  verificationStatus: verificationEnum,
+  socials: z.record(z.string()).optional(),
+  genres: z.array(z.string())
 });
 export type UserProfile = z.infer<typeof userProfileSchema>;
 
 export const postSchema = z.object({
   id: z.string().uuid(),
   authorId: z.string().uuid(),
-  content: z.string(),
+  body: z.string(),
+  mediaUrl: z.string().url().optional(),
   createdAt: z.date(),
+  visibility: z.enum(['public', 'members']).default('public')
 });
 export type Post = z.infer<typeof postSchema>;
 
@@ -24,52 +35,58 @@ export const commentSchema = z.object({
   id: z.string().uuid(),
   postId: z.string().uuid(),
   authorId: z.string().uuid(),
-  content: z.string(),
-  createdAt: z.date(),
+  body: z.string(),
+  createdAt: z.date()
 });
 export type Comment = z.infer<typeof commentSchema>;
 
 export const reactionSchema = z.object({
   id: z.string().uuid(),
-  postId: z.string().uuid(),
+  postId: z.string().uuid().optional(),
+  commentId: z.string().uuid().optional(),
   userId: z.string().uuid(),
-  type: reactionEnum,
-  createdAt: z.date(),
+  kind: reactionKindEnum,
+  createdAt: z.date()
 });
 export type Reaction = z.infer<typeof reactionSchema>;
 
 export const memeSchema = z.object({
   id: z.string().uuid(),
   authorId: z.string().uuid(),
+  prompt: z.string(),
   imageUrl: z.string().url(),
-  caption: z.string().optional(),
-  createdAt: z.date(),
+  createdAt: z.date()
 });
 export type Meme = z.infer<typeof memeSchema>;
+
+export const playlistSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string(),
+  description: z.string().optional(),
+  spotifyUrl: z.string().url().optional(),
+  orderIndex: z.number().int().default(0),
+  updatedAt: z.date()
+});
+export type Playlist = z.infer<typeof playlistSchema>;
 
 export const trackSchema = z.object({
   id: z.string().uuid(),
   playlistId: z.string().uuid(),
   title: z.string(),
   artist: z.string(),
-  url: z.string().url(),
+  spotifyUrl: z.string().url().optional(),
+  position: z.number().int()
 });
 export type Track = z.infer<typeof trackSchema>;
 
-export const playlistSchema = z.object({
-  id: z.string().uuid(),
-  ownerId: z.string().uuid(),
-  title: z.string(),
-  description: z.string().optional(),
-  createdAt: z.date(),
-});
-export type Playlist = z.infer<typeof playlistSchema>;
-
 export const gigSchema = z.object({
   id: z.string().uuid(),
-  title: z.string(),
-  location: z.string(),
-  gigDate: z.date(),
+  artistId: z.string().uuid(),
+  city: z.string(),
+  venue: z.string(),
+  startsAt: z.date(),
+  lineup: z.string().optional(),
+  ticketUrl: z.string().url().optional()
 });
 export type Gig = z.infer<typeof gigSchema>;
 
@@ -77,7 +94,50 @@ export const newsItemSchema = z.object({
   id: z.string().uuid(),
   title: z.string(),
   url: z.string().url(),
-  summary: z.string(),
+  source: z.string().optional(),
+  category: z.string().optional(),
+  region: z.string().optional(),
   publishedAt: z.date(),
+  insertedAt: z.date()
 });
 export type NewsItem = z.infer<typeof newsItemSchema>;
+
+export const reportSchema = z.object({
+  id: z.string().uuid(),
+  targetType: z.string(),
+  targetId: z.string().uuid(),
+  reason: z.string().optional(),
+  evidence: z.record(z.any()).optional(),
+  reporterId: z.string().uuid(),
+  createdAt: z.date()
+});
+export type Report = z.infer<typeof reportSchema>;
+
+export const notificationPrefSchema = z.object({
+  userId: z.string().uuid(),
+  mentions: z.boolean().default(true),
+  reactions: z.boolean().default(true),
+  gigs: z.boolean().default(true),
+  playlists: z.boolean().default(true),
+  news: z.record(z.any()).default({})
+});
+export type NotificationPref = z.infer<typeof notificationPrefSchema>;
+
+export const savedItemSchema = z.object({
+  id: z.string().uuid(),
+  userId: z.string().uuid(),
+  type: z.string(),
+  refId: z.string().uuid(),
+  createdAt: z.date()
+});
+export type SavedItem = z.infer<typeof savedItemSchema>;
+
+export const messageSchema = z.object({
+  id: z.string().uuid(),
+  convoId: z.string().uuid(),
+  senderId: z.string().uuid(),
+  body: z.string(),
+  createdAt: z.date()
+});
+export type Message = z.infer<typeof messageSchema>;
+


### PR DESCRIPTION
## Summary
- add shared zod schemas for profiles, posts, media, and more
- wire up drizzle schema & initial migration with scoring view
- provide supabase clients, RLS policies, env examples, and migration docs

## Testing
- `npm run lint:schemas`
- `npm run lint:db`
- `npm run lint:mobile`
- `npm run build:web`


------
https://chatgpt.com/codex/tasks/task_e_68b9ef192dc4832fa42d314461bb6d17