### PR TITLE
chore: add env examples and tighten RLS policies

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -1,2 +1,2 @@
-EXPO_PUBLIC_SUPABASE_URL=https://your-supabase-url.supabase.co
-EXPO_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+EXPO_PUBLIC_SUPABASE_URL="https://your-project.supabase.co"
+EXPO_PUBLIC_SUPABASE_ANON_KEY="public-anon-key"

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,2 +1,2 @@
-NEXT_PUBLIC_SUPABASE_URL=https://your-supabase-url.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+NEXT_PUBLIC_SUPABASE_URL="https://your-project.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="public-anon-key"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -45,3 +45,9 @@ Apply schema changes and row-level security policies:
 DRIZZLE_DATABASE_URL="postgres://user:pass@host:5432/db" npx drizzle-kit push:pg --config=packages/db/drizzle.config.ts
 psql "$DRIZZLE_DATABASE_URL" -f supabase/sql/rls_policies.sql
 ```
+
+## Run migrations & policies
+```bash
+DRIZZLE_DATABASE_URL="postgres://user:pass@host:5432/db" npx drizzle-kit push:pg --config=packages/db/drizzle.config.ts
+psql "$DRIZZLE_DATABASE_URL" -f supabase/sql/rls_policies.sql
+```

--- a/packages/db/.env.example
+++ b/packages/db/.env.example
@@ -1,1 +1,1 @@
-DRIZZLE_DATABASE_URL=postgres://user:pass@host:5432/db
+DRIZZLE_DATABASE_URL="postgres://user:pass@host:5432/db"

--- a/supabase/sql/rls_policies.sql
+++ b/supabase/sql/rls_policies.sql
@@ -31,7 +31,8 @@ create policy "Update own profile" on profiles for update
   using (auth.uid() = user_id)
   with check (
     auth.uid() = user_id and
-    role = (select role from profiles where user_id = auth.uid())
+    role = (select role from profiles where user_id = auth.uid()) and
+    verification = (select verification from profiles where user_id = auth.uid())
   );
 create policy "Admins manage profiles" on profiles for update
   using (auth.jwt() ->> 'role' = 'admin' or is_admin)


### PR DESCRIPTION
## Summary
- add Supabase client env examples for web, mobile, and migrations
- restrict profile updates to prevent role/verification changes by non-admins
- document running migrations and policies via Drizzle

## Testing
- `npm run lint:schemas`
- `npm run lint:db`
- `npm run build:web`
- `npm run lint:packages` *(fails: Cannot find module 'std/testing/asserts.ts' and missing Deno types)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f60653b8832f9596f96b6e678f84