### PR TITLE
feat: add auth flows and route guards

### DIFF
--- a/apps/mobile/__tests__/auth.smoke.test.tsx
+++ b/apps/mobile/__tests__/auth.smoke.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react-native';
+import Login from '../src/screens/Login';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      signInWithOtp: jest.fn(),
+      signInWithOAuth: jest.fn(),
+      mfa: { enroll: jest.fn(), verify: jest.fn() },
+      getUser: jest.fn(),
+      setSession: jest.fn(),
+      onAuthStateChange: jest.fn(() => ({ data: { subscription: { unsubscribe: jest.fn() } } })),
+    },
+  },
+}));
+
+test('renders Login screen', () => {
+  render(<Login />);
+});

--- a/apps/mobile/jest.setup.ts
+++ b/apps/mobile/jest.setup.ts
@@ -2,6 +2,36 @@ import 'react-native-gesture-handler/jestSetup';
 import mockSafeAreaContext from 'react-native-safe-area-context/jest/mock';
 import { NativeModules } from 'react-native';
 
+process.env.EXPO_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY = 'anon';
+
+jest.mock(
+  'expo-secure-store',
+  () => ({
+    getItemAsync: jest.fn().mockResolvedValue(null),
+    setItemAsync: jest.fn().mockResolvedValue(undefined),
+    deleteItemAsync: jest.fn().mockResolvedValue(undefined),
+  }),
+  { virtual: true }
+);
+
+jest.mock('./src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      signInWithOtp: jest.fn(),
+      signInWithOAuth: jest.fn(),
+      mfa: { enroll: jest.fn(), verify: jest.fn() },
+      getUser: jest.fn(),
+      setSession: jest.fn(),
+      onAuthStateChange: jest.fn(() => ({ data: { subscription: { unsubscribe: jest.fn() } } })),
+    },
+    from: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    single: jest.fn().mockResolvedValue({ data: null }),
+  },
+}));
+
 NativeModules.PlatformConstants = NativeModules.PlatformConstants || { forceTouchAvailable: false };
 
 jest.mock('react-native-reanimated', () => require('react-native-reanimated/mock'));

--- a/apps/mobile/src/components/TOTPSetup.tsx
+++ b/apps/mobile/src/components/TOTPSetup.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+import { View, Text, TextInput, Button, Image } from 'react-native';
+import { supabase } from '../lib/supabase';
+import { theme } from '../theme';
+
+export default function TOTPSetup() {
+  const [qr, setQr] = useState<string | null>(null);
+  const [factorId, setFactorId] = useState<string | null>(null);
+  const [code, setCode] = useState('');
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const { data } = await supabase.auth.mfa.enroll({ factorType: 'totp' });
+      if (data?.totp) {
+        setQr(data.totp.qr_code);
+        setFactorId(data.id);
+      }
+    })();
+  }, []);
+
+  const verify = async () => {
+    if (!factorId) return;
+    const { error } = await supabase.auth.mfa.verify({ factorId, code });
+    if (!error) {
+      const user = (await supabase.auth.getUser()).data.user;
+      if (user) {
+        await supabase.from('profiles').update({ mfa_enrolled: true }).eq('id', user.id);
+      }
+      setDone(true);
+    }
+  };
+
+  if (done) return <Text style={{ color: theme.colors.text }}>TOTP enabled</Text>;
+
+  return (
+    <View>
+      {qr && (
+        <Image source={{ uri: `data:image/png;base64,${qr}` }} style={{ width: 200, height: 200, alignSelf: 'center' }} />
+      )}
+      <Text style={{ color: theme.colors.text, marginVertical: 8 }}>
+        Save your recovery codes safely.
+      </Text>
+      <TextInput
+        value={code}
+        onChangeText={setCode}
+        keyboardType="number-pad"
+        placeholder="123456"
+        style={{ borderWidth: 1, borderColor: theme.colors.muted, padding: 8, color: theme.colors.text, marginBottom: 12 }}
+      />
+      <Button title="Verify" color={theme.colors.lime} onPress={verify} />
+    </View>
+  );
+}

--- a/apps/mobile/src/lib/session.ts
+++ b/apps/mobile/src/lib/session.ts
@@ -1,0 +1,29 @@
+import * as SecureStore from 'expo-secure-store';
+import type { Session } from '@supabase/supabase-js';
+import { supabase } from './supabase';
+
+const KEY = 'sb-session';
+
+export async function loadSession() {
+  const raw = await SecureStore.getItemAsync(KEY);
+  if (raw) {
+    const session: Session = JSON.parse(raw);
+    await supabase.auth.setSession(session);
+    return session;
+  }
+  return null;
+}
+
+export async function saveSession(session: Session | null) {
+  if (session) {
+    await SecureStore.setItemAsync(KEY, JSON.stringify(session));
+  } else {
+    await SecureStore.deleteItemAsync(KEY);
+  }
+}
+
+export function initSessionListener() {
+  supabase.auth.onAuthStateChange((_e, session) => {
+    saveSession(session);
+  });
+}

--- a/apps/mobile/src/navigation/RootNavigator.tsx
+++ b/apps/mobile/src/navigation/RootNavigator.tsx
@@ -1,5 +1,8 @@
+import { useEffect, useState } from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import Landing from '../screens/Landing';
+import type { Session } from '@supabase/supabase-js';
+import { supabase } from '../lib/supabase';
+import { loadSession, initSessionListener } from '../lib/session';
 import Login from '../screens/Login';
 import Feed from '../screens/Feed';
 import PostComposer from '../screens/PostComposer';
@@ -10,7 +13,6 @@ import Profile from '../screens/Profile';
 import Admin from '../screens/Admin';
 
 export type RootStackParamList = {
-  Landing: undefined;
   Login: undefined;
   Feed: undefined;
   PostComposer: undefined;
@@ -24,17 +26,32 @@ export type RootStackParamList = {
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export default function RootNavigator() {
+  const [session, setSession] = useState<Session | null>(null);
+
+  useEffect(() => {
+    loadSession().then(setSession);
+    const { data: sub } = supabase.auth.onAuthStateChange((_e, sess) => setSession(sess));
+    initSessionListener();
+    return () => {
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+
   return (
     <Stack.Navigator>
-      <Stack.Screen name="Landing" component={Landing} options={{ headerShown: false }} />
-      <Stack.Screen name="Login" component={Login} />
-      <Stack.Screen name="Feed" component={Feed} />
-      <Stack.Screen name="PostComposer" component={PostComposer} />
-      <Stack.Screen name="MemeStudio" component={MemeStudio} />
-      <Stack.Screen name="Playlists" component={Playlists} />
-      <Stack.Screen name="GigRadar" component={GigRadar} />
-      <Stack.Screen name="Profile" component={Profile} />
-      <Stack.Screen name="Admin" component={Admin} />
+      {session ? (
+        <>
+          <Stack.Screen name="Feed" component={Feed} />
+          <Stack.Screen name="PostComposer" component={PostComposer} />
+          <Stack.Screen name="MemeStudio" component={MemeStudio} />
+          <Stack.Screen name="Playlists" component={Playlists} />
+          <Stack.Screen name="GigRadar" component={GigRadar} />
+          <Stack.Screen name="Profile" component={Profile} />
+          <Stack.Screen name="Admin" component={Admin} />
+        </>
+      ) : (
+        <Stack.Screen name="Login" component={Login} />
+      )}
     </Stack.Navigator>
   );
 }

--- a/apps/mobile/src/screens/Login.tsx
+++ b/apps/mobile/src/screens/Login.tsx
@@ -1,16 +1,32 @@
 import { useState } from 'react';
 import { View, TextInput, Button, Text } from 'react-native';
 import { supabase } from '../lib/supabase';
+import TOTPSetup from '../components/TOTPSetup';
 import { theme } from '../theme';
+
+type Provider = 'google' | 'apple';
 
 export default function Login() {
   const [email, setEmail] = useState('');
   const [sent, setSent] = useState(false);
+  const [showTotp, setShowTotp] = useState(false);
 
   const send = async () => {
     const { error } = await supabase.auth.signInWithOtp({ email });
     if (!error) setSent(true);
   };
+
+  const oauth = async (provider: Provider) => {
+    await supabase.auth.signInWithOAuth({ provider });
+  };
+
+  if (showTotp) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', padding: 16, backgroundColor: theme.colors.background }}>
+        <TOTPSetup />
+      </View>
+    );
+  }
 
   return (
     <View style={{ flex: 1, justifyContent: 'center', padding: 16, backgroundColor: theme.colors.background }}>
@@ -26,7 +42,13 @@ export default function Login() {
             keyboardType="email-address"
             style={{ borderWidth: 1, borderColor: theme.colors.muted, padding: 8, color: theme.colors.text, marginBottom: 12 }}
           />
-          <Button title="Send Magic Link" onPress={send} />
+          <Button title="Send Magic Link" color={theme.colors.lime} onPress={send} />
+          <View style={{ height: 12 }} />
+          <Button title="Sign in with Google" color={theme.colors.lime} onPress={() => oauth('google')} />
+          <View style={{ height: 12 }} />
+          <Button title="Sign in with Apple" color={theme.colors.lime} onPress={() => oauth('apple')} />
+          <View style={{ height: 12 }} />
+          <Button title="Setup TOTP" color={theme.colors.lime} onPress={() => setShowTotp(true)} />
         </>
       )}
     </View>

--- a/apps/mobile/src/screens/Profile.tsx
+++ b/apps/mobile/src/screens/Profile.tsx
@@ -32,6 +32,7 @@ export default function Profile({ route }: NativeStackScreenProps<RootStackParam
   });
 
   const isOwner = sessionId === profileId;
+  const canEdit = isOwner && !!profile?.verified;
   const [name, setName] = useState('');
   useEffect(() => {
     if (profile) setName(profile.name ?? '');
@@ -48,7 +49,7 @@ export default function Profile({ route }: NativeStackScreenProps<RootStackParam
       <Text style={{ color: theme.colors.text, fontSize: 24 }}>
         {profile.name} {profile.verified && '✅'}
       </Text>
-      {isOwner && (
+      {canEdit && (
         <>
           <TextInput
             value={name}

--- a/apps/web/__tests__/auth.spec.tsx
+++ b/apps/web/__tests__/auth.spec.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { vi, describe, it, expect } from 'vitest';
+import AuthForm from '../components/auth/AuthForm';
+
+vi.mock('../lib/supabase-browser', () => ({
+  getBrowserClient: () => ({
+    auth: {
+      signInWithOtp: vi.fn().mockResolvedValue({ error: null }),
+      signInWithOAuth: vi.fn(),
+      mfa: { enroll: vi.fn(), verify: vi.fn() },
+      getUser: vi.fn().mockResolvedValue({ data: { user: null } })
+    }
+  })
+}));
+
+describe('AuthForm', () => {
+  it('renders email input', () => {
+    render(<AuthForm />);
+    expect(screen.getByPlaceholderText(/example/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(auth)/callback/route.ts
+++ b/apps/web/app/(auth)/callback/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const code = url.searchParams.get('code');
+  if (code) {
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      { auth: { persistSession: false } }
+    );
+    await supabase.auth.exchangeCodeForSession(code);
+  }
+  return NextResponse.redirect(new URL('/', req.url));
+}

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -1,0 +1,10 @@
+'use client';
+import AuthForm from '@/components/auth/AuthForm';
+
+export default function Page() {
+  return (
+    <div className="mx-auto mt-24 max-w-md p-4">
+      <AuthForm />
+    </div>
+  );
+}

--- a/apps/web/app/(marketing)/page.tsx
+++ b/apps/web/app/(marketing)/page.tsx
@@ -1,18 +1,37 @@
-import Header from '@/components/landing/Header';
+'use client';
+import Link from 'next/link';
+import Logo from '@/components/Logo';
+import UserMenu from '@/components/auth/UserMenu';
 import Hero from '@/components/landing/Hero';
 import FeatureGrid from '@/components/landing/FeatureGrid';
 import FeedPreview from '@/components/landing/FeedPreview';
 import HowItWorks from '@/components/landing/HowItWorks';
 import CtaBand from '@/components/landing/CtaBand';
 import Footer from '@/components/landing/Footer';
+import { SessionProvider, useSession } from '@/app/providers';
 import './_styles.css';
 
 export const dynamic = 'force-dynamic';
 
-export default function Page() {
+function Content() {
+  const { session } = useSession();
   return (
     <>
-      <Header />
+      <header className="py-6">
+        <div className="mx-auto flex max-w-[1200px] items-center justify-between px-6">
+          <Logo className="h-6 w-6" />
+          {session ? (
+            <UserMenu />
+          ) : (
+            <Link
+              href="/login"
+              className="rounded bg-lime px-4 py-2 font-bold text-black"
+            >
+              Login / Sign Up
+            </Link>
+          )}
+        </div>
+      </header>
       <main>
         <Hero />
         <FeatureGrid />
@@ -24,5 +43,13 @@ export default function Page() {
       </main>
       <Footer />
     </>
+  );
+}
+
+export default function Page() {
+  return (
+    <SessionProvider>
+      <Content />
+    </SessionProvider>
   );
 }

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -1,0 +1,38 @@
+'use client';
+import { createContext, useContext, useEffect, useState } from 'react';
+import { getBrowserClient, type SupabaseClient } from '@/lib/supabase-browser';
+import type { Session } from '@supabase/supabase-js';
+
+interface SessionContextValue {
+  supabase: SupabaseClient;
+  session: Session | null;
+}
+
+const SessionContext = createContext<SessionContextValue | undefined>(undefined);
+
+export function SessionProvider({ children }: { children: React.ReactNode }) {
+  const supabase = getBrowserClient();
+  const [session, setSession] = useState<Session | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => setSession(data.session));
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session);
+    });
+    return () => {
+      listener.subscription.unsubscribe();
+    };
+  }, [supabase]);
+
+  return (
+    <SessionContext.Provider value={{ supabase, session }}>
+      {children}
+    </SessionContext.Provider>
+  );
+}
+
+export function useSession() {
+  const ctx = useContext(SessionContext);
+  if (!ctx) throw new Error('useSession must be used within SessionProvider');
+  return ctx;
+}

--- a/apps/web/components/auth/AuthForm.tsx
+++ b/apps/web/components/auth/AuthForm.tsx
@@ -1,0 +1,61 @@
+"use client";
+import { useState } from 'react';
+import { getBrowserClient } from '../../lib/supabase-browser';
+
+export default function AuthForm() {
+  const supabase = getBrowserClient();
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const sendLink = async () => {
+    setError(null);
+    const { error } = await supabase.auth.signInWithOtp({ email, options: { emailRedirectTo: `${location.origin}/callback` } });
+    if (error) {
+      setError(error.message);
+    } else {
+      setMessage('Check your email for a magic link.');
+    }
+  };
+
+  const oauth = async (provider: 'google' | 'apple') => {
+    await supabase.auth.signInWithOAuth({ provider, options: { redirectTo: `${location.origin}/callback` } });
+  };
+
+  return (
+    <div className="space-y-4">
+      <input
+        type="email"
+        placeholder="you@example.com"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        className="w-full rounded border border-lime bg-transparent p-2 text-white"
+      />
+      <button
+        type="button"
+        onClick={sendLink}
+        className="w-full rounded bg-lime p-2 font-bold text-black"
+      >
+        Send Magic Link
+      </button>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => oauth('google')}
+          className="flex-1 rounded border border-lime p-2 text-lime"
+        >
+          Google
+        </button>
+        <button
+          type="button"
+          onClick={() => oauth('apple')}
+          className="flex-1 rounded border border-lime p-2 text-lime"
+        >
+          Apple
+        </button>
+      </div>
+      {message && <p className="text-sm text-lime">{message}</p>}
+      {error && <p className="text-sm text-red-500">{error}</p>}
+    </div>
+  );
+}

--- a/apps/web/components/auth/TOTPSetup.tsx
+++ b/apps/web/components/auth/TOTPSetup.tsx
@@ -1,0 +1,61 @@
+"use client";
+import { useEffect, useState } from 'react';
+import { getBrowserClient } from '@/lib/supabase-browser';
+
+export default function TOTPSetup() {
+  const supabase = getBrowserClient();
+  const [qr, setQr] = useState<string | null>(null);
+  const [factorId, setFactorId] = useState<string | null>(null);
+  const [code, setCode] = useState('');
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const { data, error } = await supabase.auth.mfa.enroll({ factorType: 'totp' });
+      if (!error && data?.totp) {
+        setQr(data.totp.qr_code);
+        setFactorId(data.id);
+      }
+    })();
+  }, [supabase]);
+
+  const verify = async () => {
+    if (!factorId) return;
+    const { error } = await supabase.auth.mfa.verify({ factorId, code } as any);
+    if (error) {
+      setError(error.message);
+    } else {
+      const user = (await supabase.auth.getUser()).data.user;
+      if (user) {
+        await supabase.from('profiles').update({ mfa_enrolled: true }).eq('id', user.id);
+      }
+      setDone(true);
+    }
+  };
+
+  if (done) return <p className="text-lime">TOTP enabled</p>;
+
+  return (
+    <div className="space-y-4">
+      {qr && (
+        <img src={`data:image/png;base64,${qr}`} alt="TOTP QR" className="mx-auto" />
+      )}
+      <p className="text-sm text-white">Store your recovery codes safely.</p>
+      <input
+        value={code}
+        onChange={(e) => setCode(e.target.value)}
+        placeholder="123456"
+        className="w-full rounded border border-lime bg-transparent p-2 text-white"
+      />
+      <button
+        type="button"
+        onClick={verify}
+        className="w-full rounded bg-lime p-2 font-bold text-black"
+      >
+        Verify
+      </button>
+      {error && <p className="text-sm text-red-500">{error}</p>}
+    </div>
+  );
+}

--- a/apps/web/components/auth/UserMenu.tsx
+++ b/apps/web/components/auth/UserMenu.tsx
@@ -1,0 +1,54 @@
+'use client';
+import { useState } from 'react';
+import Link from 'next/link';
+import { getBrowserClient } from '@/lib/supabase-browser';
+import { useSession } from '@/app/providers';
+
+export default function UserMenu() {
+  const { session } = useSession();
+  const supabase = getBrowserClient();
+  const [open, setOpen] = useState(false);
+
+  if (!session) return null;
+  const avatar = session.user.user_metadata?.avatar_url as string | undefined;
+  const role = session.user.app_metadata?.role as string | undefined;
+
+  const signOut = async () => {
+    await supabase.auth.signOut();
+    location.href = '/login';
+  };
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="h-8 w-8 overflow-hidden rounded-full border border-lime"
+      >
+        {avatar ? (
+          <img src={avatar} alt="avatar" className="h-full w-full object-cover" />
+        ) : (
+          <span className="block h-full w-full bg-lime" />
+        )}
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 w-40 rounded bg-black p-2 text-white">
+          <Link href="/profile" className="block px-2 py-1 hover:bg-lime hover:text-black">
+            Profile
+          </Link>
+          {role === 'admin' && (
+            <Link href="/admin" className="block px-2 py-1 hover:bg-lime hover:text-black">
+              Admin
+            </Link>
+          )}
+          <button
+            type="button"
+            onClick={signOut}
+            className="block w-full px-2 py-1 text-left hover:bg-lime hover:text-black"
+          >
+            Sign out
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/lib/auth-server.ts
+++ b/apps/web/lib/auth-server.ts
@@ -1,0 +1,26 @@
+'use server';
+import { createClient } from '@supabase/supabase-js';
+import type { Session } from '@supabase/supabase-js';
+
+function serverClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+export async function signInWithOtp(email: string) {
+  const supabase = serverClient();
+  const { error } = await supabase.auth.signInWithOtp({ email });
+  if (error) throw error;
+}
+
+export async function signOut() {
+  const supabase = serverClient();
+  await supabase.auth.signOut();
+}
+
+export async function getSession(): Promise<Session | null> {
+  const supabase = serverClient();
+  const { data } = await supabase.auth.getSession();
+  return data.session;
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  const token = req.cookies.get('sb-access-token');
+  if (!token) {
+    const url = req.nextUrl.clone();
+    url.pathname = '/login';
+    return NextResponse.redirect(url);
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    '/admin/:path*',
+    '/feed/:path*',
+    '/meme-studio/:path*',
+    '/gig-radar/:path*',
+    '/playlists/:path*',
+    '/profile/:path*',
+  ],
+};


### PR DESCRIPTION
## Summary
- add web auth pages, session provider, and route protection
- enable mobile login with OAuth, TOTP, and secure sessions
- include tests for auth components on web and mobile

## Testing
- `npm run build:web`
- `npm test --prefix apps/web`
- `cd apps/mobile && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f816ec34832f9247a12cf9449b44