### PR TITLE
feat: improve auth ux

### DIFF
--- a/apps/mobile/src/components/TOTPSetup.tsx
+++ b/apps/mobile/src/components/TOTPSetup.tsx
@@ -8,6 +8,7 @@ export default function TOTPSetup() {
   const [factorId, setFactorId] = useState<string | null>(null);
   const [code, setCode] = useState('');
   const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     (async () => {
@@ -21,8 +22,11 @@ export default function TOTPSetup() {
 
   const verify = async () => {
     if (!factorId) return;
+    setError(null);
     const { error } = await supabase.auth.mfa.verify({ factorId, code });
-    if (!error) {
+    if (error) {
+      setError(error.message);
+    } else {
       const user = (await supabase.auth.getUser()).data.user;
       if (user) {
         await supabase.from('profiles').update({ mfa_enrolled: true }).eq('id', user.id);
@@ -49,6 +53,9 @@ export default function TOTPSetup() {
         style={{ borderWidth: 1, borderColor: theme.colors.muted, padding: 8, color: theme.colors.text, marginBottom: 12 }}
       />
       <Button title="Verify" color={theme.colors.lime} onPress={verify} />
+      {error && (
+        <Text style={{ color: 'red', marginTop: 12 }}>{error}</Text>
+      )}
     </View>
   );
 }

--- a/apps/mobile/src/navigation/RootNavigator.tsx
+++ b/apps/mobile/src/navigation/RootNavigator.tsx
@@ -47,7 +47,9 @@ export default function RootNavigator() {
           <Stack.Screen name="Playlists" component={Playlists} />
           <Stack.Screen name="GigRadar" component={GigRadar} />
           <Stack.Screen name="Profile" component={Profile} />
-          <Stack.Screen name="Admin" component={Admin} />
+          {session.user.app_metadata?.role === 'admin' && (
+            <Stack.Screen name="Admin" component={Admin} />
+          )}
         </>
       ) : (
         <Stack.Screen name="Login" component={Login} />

--- a/apps/mobile/src/screens/Login.tsx
+++ b/apps/mobile/src/screens/Login.tsx
@@ -10,14 +10,25 @@ export default function Login() {
   const [email, setEmail] = useState('');
   const [sent, setSent] = useState(false);
   const [showTotp, setShowTotp] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const send = async () => {
+    setError(null);
     const { error } = await supabase.auth.signInWithOtp({ email });
-    if (!error) setSent(true);
+    if (error) {
+      setError(error.message);
+    } else {
+      setSent(true);
+    }
   };
 
   const oauth = async (provider: Provider) => {
-    await supabase.auth.signInWithOAuth({ provider });
+    setError(null);
+    try {
+      await supabase.auth.signInWithOAuth({ provider });
+    } catch (e: any) {
+      setError(e.message);
+    }
   };
 
   if (showTotp) {
@@ -49,6 +60,9 @@ export default function Login() {
           <Button title="Sign in with Apple" color={theme.colors.lime} onPress={() => oauth('apple')} />
           <View style={{ height: 12 }} />
           <Button title="Setup TOTP" color={theme.colors.lime} onPress={() => setShowTotp(true)} />
+          {error && (
+            <Text style={{ color: 'red', marginTop: 12 }}>{error}</Text>
+          )}
         </>
       )}
     </View>

--- a/apps/web/lib/auth-server.ts
+++ b/apps/web/lib/auth-server.ts
@@ -10,7 +10,10 @@ function serverClient() {
 
 export async function signInWithOtp(email: string) {
   const supabase = serverClient();
-  const { error } = await supabase.auth.signInWithOtp({ email });
+  const { error } = await supabase.auth.signInWithOtp({
+    email,
+    options: { emailRedirectTo: `${process.env.NEXT_PUBLIC_SITE_URL ?? ''}/callback` },
+  });
   if (error) throw error;
 }
 


### PR DESCRIPTION
## Summary
- add redirect option when signing in with OTP
- surface errors in mobile login and TOTP setup
- hide Admin screen unless user has admin role

## Testing
- `npm run build --prefix apps/web` (fails: Supabase env vars missing)
- `npm run test --prefix apps/web`
- `npm run test --prefix apps/mobile`


------
https://chatgpt.com/codex/tasks/task_e_68bad6ff95ac832f8e19da08c2f43e45