### PR TITLE
feat: add moderation queue and push notification prefs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           node-version: 20
       - run: npm run lint:packages
       - run: npm test --workspaces --if-present
+      - run: npm run build --workspaces --if-present
   functions:
     runs-on: ubuntu-latest
     steps:

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -3,7 +3,18 @@
     "name": "thecueroom-mobile",
     "slug": "thecueroom-mobile",
     "version": "1.0.0",
-    "plugins": ["expo-notifications"],
+    "plugins": [
+      [
+        "expo-notifications",
+        { "icon": "./assets/notification-icon.png", "color": "#ffffff" }
+      ]
+    ],
+    "android": {
+      "googleServicesFile": "./google-services.json"
+    },
+    "ios": {
+      "googleServicesFile": "./GoogleService-Info.plist"
+    },
     "extra": {
       "eas": {
         "projectId": "CHANGE_ME"

--- a/apps/mobile/src/components/ReportButton.tsx
+++ b/apps/mobile/src/components/ReportButton.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Alert, Button } from 'react-native';
+import { Alert, Button, Platform } from 'react-native';
 import { supabase } from '../lib/supabase';
 
 interface Props {
@@ -13,7 +13,15 @@ export default function ReportButton({ targetId, targetType }: Props) {
   const submit = async () => {
     setLoading(true);
     try {
-      await supabase.from('reports').insert({ target_id: targetId, target_type: targetType });
+      let reason: string | undefined;
+      if (Platform.OS === 'ios') {
+        reason = await new Promise<string | undefined>((resolve) => {
+          Alert.prompt('Reason for report?', undefined, (text) => resolve(text || undefined));
+        });
+      }
+      await supabase
+        .from('reports')
+        .insert({ target_id: targetId, target_type: targetType, reason });
       Alert.alert('Report submitted');
     } finally {
       setLoading(false);

--- a/apps/mobile/src/lib/notifications.ts
+++ b/apps/mobile/src/lib/notifications.ts
@@ -8,7 +8,7 @@ declare module 'expo-notifications' {
   export function getExpoPushTokenAsync(options?: { projectId?: string }): Promise<{ data: string }>;
 }
 
-export async function registerDeviceForPush() {
+export async function registerDeviceForPush(categories: string[] = []) {
   const Notifications = await import('expo-notifications');
   let { status } = await Notifications.getPermissionsAsync();
   if (status !== 'granted') {
@@ -24,10 +24,12 @@ export async function registerDeviceForPush() {
     data: { user }
   } = await supabase.auth.getUser();
   if (user) {
-    await supabase.from('notification_prefs').upsert(
-      { userId: user.id, expoPushToken: token },
-      { onConflict: 'userId' }
-    );
+    await supabase
+      .from('notification_prefs')
+      .upsert(
+        { userId: user.id, expoPushToken: token, categories },
+        { onConflict: 'userId' }
+      );
   }
   return token;
 }

--- a/apps/web/app/(admin)/admin/actions.ts
+++ b/apps/web/app/(admin)/admin/actions.ts
@@ -16,15 +16,21 @@ async function requireAdmin() {
   if (session?.user.user_metadata.role !== 'admin') {
     throw new Error('Unauthorized');
   }
-  return serverClient();
+  return { supabase: serverClient(), session };
+}
+
+async function audit(supabase: ReturnType<typeof serverClient>, reportId: string, action: string, actorId: string) {
+  await supabase.from('moderation_audit').insert({ report_id: reportId, action, actor_id: actorId });
 }
 
 export async function approveReport(id: string) {
-  const supabase = await requireAdmin();
+  const { supabase, session } = await requireAdmin();
   await supabase.from('reports').update({ status: 'approved' }).eq('id', id);
+  await audit(supabase, id, 'approved', session.user.id);
 }
 
 export async function rejectReport(id: string) {
-  const supabase = await requireAdmin();
+  const { supabase, session } = await requireAdmin();
   await supabase.from('reports').update({ status: 'rejected' }).eq('id', id);
+  await audit(supabase, id, 'rejected', session.user.id);
 }

--- a/apps/web/app/api/notify/route.ts
+++ b/apps/web/app/api/notify/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { notificationCategoryEnum } from '@thecueroom/schemas';
 
 export async function POST(req: Request) {
   const supabase = createClient(
@@ -12,7 +13,8 @@ export async function POST(req: Request) {
   if (user?.user_metadata?.role !== 'admin') {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-  const { category, message } = await req.json();
+  const { category: rawCategory, message } = await req.json();
+  const category = notificationCategoryEnum.parse(rawCategory);
   const { data } = await supabase
     .from('notification_prefs')
     .select('expoPushToken')

--- a/apps/web/components/moderation/QueueTable.tsx
+++ b/apps/web/components/moderation/QueueTable.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { useState, useTransition } from 'react';
+import { approveReport, rejectReport } from '@/app/(admin)/admin/actions';
+
 interface Report {
   id: string;
   targetType: string;
@@ -12,19 +15,47 @@ const mockQueue: Report[] = [
 ];
 
 export default function QueueTable() {
+  const [queue, setQueue] = useState(mockQueue);
+  const [pending, startTransition] = useTransition();
+
+  const handle = (fn: typeof approveReport, id: string) =>
+    startTransition(async () => {
+      await fn(id);
+      setQueue((q) => q.filter((r) => r.id !== id));
+    });
+
   return (
     <table className="min-w-full text-sm">
       <thead>
         <tr>
           <th className="px-2 py-1 text-left">Target</th>
           <th className="px-2 py-1 text-left">Reason</th>
+          <th className="px-2 py-1 text-left">Actions</th>
         </tr>
       </thead>
       <tbody>
-        {mockQueue.map((r) => (
+        {queue.map((r) => (
           <tr key={r.id} className="border-t">
             <td className="px-2 py-1">{r.targetType}</td>
             <td className="px-2 py-1">{r.reason ?? 'n/a'}</td>
+            <td className="px-2 py-1">
+              <button
+                type="button"
+                className="mr-2 rounded bg-green-600 px-2 py-1 text-white"
+                disabled={pending}
+                onClick={() => handle(approveReport, r.id)}
+              >
+                Approve
+              </button>
+              <button
+                type="button"
+                className="rounded bg-red-600 px-2 py-1 text-white"
+                disabled={pending}
+                onClick={() => handle(rejectReport, r.id)}
+              >
+                Reject
+              </button>
+            </td>
           </tr>
         ))}
       </tbody>

--- a/apps/web/components/moderation/ReportButton.tsx
+++ b/apps/web/components/moderation/ReportButton.tsx
@@ -11,12 +11,13 @@ export default function ReportButton({ targetId, targetType }: Props) {
   const [submitting, setSubmitting] = useState(false);
 
   const submit = async () => {
+    const reason = window.prompt('Reason for report?') ?? undefined;
     setSubmitting(true);
     try {
       await fetch('/api/report', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ targetId, targetType })
+        body: JSON.stringify({ targetId, targetType, reason })
       });
     } finally {
       setSubmitting(false);

--- a/apps/web/e2e/feed.spec.ts
+++ b/apps/web/e2e/feed.spec.ts
@@ -1,6 +1,10 @@
 import { test, expect } from '@playwright/test';
 
-test('feed page loads', async ({ page }) => {
+test('feed page click-through', async ({ page }) => {
   await page.goto('/feed');
   await expect(page).toHaveURL(/feed/);
+  const firstLink = page.getByRole('link').first();
+  if (await firstLink.isVisible()) {
+    await firstLink.click();
+  }
 });

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -20,6 +20,7 @@ npm ci
 npm run build
 npm test
 vercel env pull .env
+vercel env push
 vercel deploy --prod
 cd ../..
 ```

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -44,3 +44,7 @@ watchman watch-del-all
 rm -rf $TMPDIR/metro*
 npm start --prefix apps/mobile -- --reset-cache
 ```
+- If pod install fails on iOS:
+```bash
+cd apps/mobile/ios && rm -rf Pods && pod install && cd ../..
+```

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -113,10 +113,18 @@ export const reportSchema = z.object({
 });
 export type Report = z.infer<typeof reportSchema>;
 
+export const notificationCategoryEnum = z.enum([
+  'general',
+  'gigs',
+  'news',
+  'marketing'
+]);
+export type NotificationCategory = z.infer<typeof notificationCategoryEnum>;
+
 export const notificationPrefSchema = z.object({
   userId: z.string().uuid(),
   expoPushToken: z.string().optional(),
-  categories: z.array(z.string()).default([]),
+  categories: z.array(notificationCategoryEnum).default([]),
   mentions: z.boolean().default(true),
   reactions: z.boolean().default(true),
   gigs: z.boolean().default(true),


### PR DESCRIPTION
## Summary
- add client/server moderation actions with audit trail
- configure Expo push notifications and category schema
- update CI workflow and deployment docs

## Testing
- `npm run lint:packages` *(fails: Cannot find module 'npm:@supabase/supabase-js@2.42.0')*
- `deno fmt --check` *(fails: Found 4 not formatted files in 23 files)*
- `deno check */index.ts` *(fails: Could not find a matching package for 'npm:fast-xml-parser@4.2.7')*
- `deno test` *(fails: Relative import path "std/testing/asserts.ts" not prefixed with / or ./ or ../)*
- `npm run lint --prefix apps/web` *(fails: ESLint couldn't find an eslint.config file)*
- `npm ci --prefix apps/web` *(fails: lock file's eslint-config-next@14.2.3 does not satisfy eslint-config-next@15.5.2)*
- `npm run build --prefix apps/web` *(fails: next: not found)*
- `npm test --prefix apps/web` *(fails: vitest: not found)*
- `npm run e2e --prefix apps/web` *(fails: playwright: not found)*
- `npm run lint --prefix apps/mobile` *(fails: Unexpected any in Feed.tsx & Login.tsx)*
- `npm run build --prefix apps/mobile` *(fails: Missing script "build")*
- `npm run align --prefix apps/mobile`
- `npm test --prefix apps/mobile`


------
https://chatgpt.com/codex/tasks/task_e_68bb02b91d00832fbd40bb5e8fa88ffc