### PR TITLE
test(mobile): clear timers after tests

### DIFF
--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   preset: 'jest-expo',
-  setupFiles: ['./jest.setup.ts']
+  setupFilesAfterEnv: ['./jest.setup.ts']
 };

--- a/apps/mobile/jest.setup.ts
+++ b/apps/mobile/jest.setup.ts
@@ -38,3 +38,12 @@ jest.mock('react-native-reanimated', () => require('react-native-reanimated/mock
 jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper');
 jest.mock('react-native-screens');
 jest.mock('react-native-safe-area-context', () => mockSafeAreaContext);
+
+afterEach(() => {
+  jest.clearAllMocks();
+  jest.clearAllTimers();
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});


### PR DESCRIPTION
## Summary
- clear mocks and timers after each mobile test
- restore real timers after all tests
- load test setup after environment initialization

## Testing
- `npm test`
- `npm run lint:mobile` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1c9e493c832fa938a589561c84af