### PR TITLE
chore(mobile): align Expo config and Jest setup

### DIFF
--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -2,6 +2,9 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['react-native-reanimated/plugin'],
+    plugins: [
+      // any other plugins first …
+      'react-native-reanimated/plugin', // MUST be last
+    ],
   };
 };

--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -1,4 +1,8 @@
 module.exports = {
   preset: 'jest-expo',
-  setupFilesAfterEnv: ['./jest.setup.ts']
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(@react-native|react-native|react-native-.*|@react-navigation|expo(nent)?|@expo(nent)?/.*|expo-modules-core|react-native-svg)/)'
+  ],
 };

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -1,53 +1,29 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { getDefaultConfig } = require('expo/metro-config');
 
-/**
- * Expo-first Metro config with:
- *  - Node core module guard (prevents bundling http/fs/path/etc. into RN)
- *  - disableHierarchicalLookup hardening
- *  - Optional react-native-svg-transformer (if installed)
- */
+// Start with Expo default (Doctor requires this)
 const config = getDefaultConfig(__dirname);
 
+// Node builtins hard guard (kept)
+const FORBIDDEN = new Set([
+  'http','https','url','fs','path','zlib','stream','crypto','util','net','tls','events'
+]);
+const origResolveRequest = config.resolver.resolveRequest;
+config.resolver.resolveRequest = (ctx, name, platform) => {
+  if (FORBIDDEN.has(name)) {
+    throw new Error(`[mobile] Node builtin "${name}" imported – not supported in React Native/Hermes.`);
+  }
+  if (origResolveRequest) return origResolveRequest(ctx, name, platform);
+  return require('metro-resolver').resolve(ctx, name, platform);
+};
 config.resolver.disableHierarchicalLookup = true;
 
-// --- Guard: forbid Node core modules in app code
-const FORBIDDEN = new Set([
-  'http',
-  'https',
-  'url',
-  'fs',
-  'path',
-  'zlib',
-  'stream',
-  'crypto',
-  'util',
-  'net',
-  'tls',
-  'events'
-]);
-const originalResolveRequest = config.resolver.resolveRequest;
-config.resolver.resolveRequest = function (context, moduleName, platform) {
-  if (FORBIDDEN.has(moduleName)) {
-    throw new Error(
-      `[mobile] Node builtin "${moduleName}" imported — not supported in React Native/Hermes.`
-    );
-  }
-  if (typeof originalResolveRequest === 'function') {
-    return originalResolveRequest(context, moduleName, platform);
-  }
-  return context.resolveRequest(moduleName, platform);
-};
-
-// Optional react-native-svg-transformer
+// Optional: react-native-svg-transformer if installed
 try {
-  const svgTransformer = require.resolve('react-native-svg-transformer');
-  config.transformer.babelTransformerPath = svgTransformer;
-  const { assetExts, sourceExts } = config.resolver;
-  config.resolver.assetExts = assetExts.filter((ext) => ext !== 'svg');
-  config.resolver.sourceExts = [...sourceExts, 'svg'];
-} catch {
-  // transformer not installed; ignore
-}
+  const tr = require.resolve('react-native-svg-transformer');
+  config.transformer.babelTransformerPath = tr;
+  config.resolver.assetExts = config.resolver.assetExts.filter((ext) => ext !== 'svg');
+  if (!config.resolver.sourceExts.includes('svg')) config.resolver.sourceExts.push('svg');
+} catch { /* ok if not installed */ }
 
 module.exports = config;

--- a/apps/mobile/scripts/expo-dep-guard.mjs
+++ b/apps/mobile/scripts/expo-dep-guard.mjs
@@ -4,6 +4,7 @@ import { spawnSync } from 'node:child_process';
 import os from 'node:os';
 
 const ROOT = process.cwd();
+const isCI = process.argv.includes('--ci');
 
 function run(cmd, args, opts = {}) {
   const res = spawnSync(cmd, args, { stdio: 'inherit', ...opts });
@@ -12,29 +13,24 @@ function run(cmd, args, opts = {}) {
     process.exit(res.status ?? 1);
   }
 }
-
 function checkContains(file, needles) {
   const p = path.join(ROOT, file);
-  if (!existsSync(p)) {
-    console.error(`[guard] Missing file: ${file}`);
-    process.exit(1);
-  }
+  if (!existsSync(p)) { console.error(`[guard] Missing file: ${file}`); process.exit(1); }
   const s = readFileSync(p, 'utf8');
   for (const n of needles) {
-    if (!s.includes(n)) {
-      console.error(`[guard] ${file} missing required snippet: ${n}`);
-      process.exit(1);
-    }
+    if (!s.includes(n)) { console.error(`[guard] ${file} missing required snippet: ${n}`); process.exit(1); }
   }
+  return s;
 }
 
 console.log('\n[guard] Expo dependency alignment — start');
-run('node', ['scripts/fix-expo-versions.mjs']);
-run('npx', ['--yes', 'expo-doctor']);
-run('npx', ['expo', 'install', '--fix']);
+run('npx', ['expo', 'doctor']);                // ✅ correct binary
+run('npx', ['expo', 'install', '--fix']);      // align all
+// Re-pin frequent drifters
 run('npx', ['expo', 'install', 'react-native-screens', 'react-native-safe-area-context']);
-checkContains('babel.config.js', ['babel-preset-expo', 'react-native-reanimated/plugin']);
-checkContains('metro.config.js', ['expo/metro-config', 'FORBIDDEN', 'disableHierarchicalLookup']);
+
+checkContains('babel.config.js', ['babel-preset-expo','react-native-reanimated/plugin']);
+checkContains('metro.config.js', ['expo/metro-config','getDefaultConfig','FORBIDDEN','disableHierarchicalLookup']);
 checkContains('jest.config.js', ["preset: 'jest-expo'"]);
 checkContains('jest.setup.ts', [
   'NativeAnimatedHelper',
@@ -42,7 +38,10 @@ checkContains('jest.setup.ts', [
   'react-native-gesture-handler/jestSetup',
   'react-native-screens',
   'react-native-safe-area-context',
-  'PlatformConstants'
+  'PlatformConstants',
 ]);
+
 if (os.platform() === 'darwin') run('npx', ['pod-install']);
+
 console.log('[guard] Expo dependency alignment — OK');
+


### PR DESCRIPTION
## Summary
- align Metro config with Expo defaults and enforce Node builtin guard
- ensure Babel, Jest config and mocks follow Expo Doctor requirements
- add Expo dependency alignment script

## Testing
- `npm run lint:mobile` *(fails: Unexpected any in Feed.tsx & Login.tsx)*
- `npm run test:mobile` *(fails: expo-image SyntaxError during Navigation.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bb26e46370832f9f4f69631c6a5d79