### PR TITLE
chore: add browser supabase client and expo doctor guard

### DIFF
--- a/apps/mobile/scripts/expo-dep-guard.mjs
+++ b/apps/mobile/scripts/expo-dep-guard.mjs
@@ -24,10 +24,9 @@ function checkContains(file, needles) {
 }
 
 console.log('\n[guard] Expo dependency alignment — start');
-run('npx', ['expo', 'doctor']);                // ✅ correct binary
-run('npx', ['expo', 'install', '--fix']);      // align all
-// Re-pin frequent drifters
-run('npx', ['expo', 'install', 'react-native-screens', 'react-native-safe-area-context']);
+run('npx', ['expo-doctor']);              // official doctor shim
+run('npx', ['expo', 'install', '--fix']); // align all managed deps
+run('npx', ['expo', 'install', 'react-native-screens', 'react-native-safe-area-context']); // re-pin
 
 checkContains('babel.config.js', ['babel-preset-expo','react-native-reanimated/plugin']);
 checkContains('metro.config.js', ['expo/metro-config','getDefaultConfig','FORBIDDEN','disableHierarchicalLookup']);

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { createContext, useContext, useEffect, useState } from 'react';
-import { getBrowserClient, type SupabaseClient } from '@/lib/supabase-browser';
-import type { Session } from '@supabase/supabase-js';
+import { getBrowserClient } from '@/lib/supabase-browser';
+import type { Session, SupabaseClient } from '@supabase/supabase-js';
 
 interface SessionContextValue {
   supabase: SupabaseClient;

--- a/apps/web/lib/supabase-browser.ts
+++ b/apps/web/lib/supabase-browser.ts
@@ -6,7 +6,7 @@ export function createBrowserClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL || 'http://localhost';
   const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'anon';
   return createClient(url, anon, {
-    auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true },
+    auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true }
   });
 }
 
@@ -14,8 +14,3 @@ export function getBrowserClient() {
   if (!client) client = createBrowserClient();
   return client;
 }
-
-// Convenience export for modules that expect `supabase`
-export const supabase = getBrowserClient();
-
-export type { SupabaseClient } from '@supabase/supabase-js';


### PR DESCRIPTION
## Summary
- streamline Supabase browser client and provider import
- use `expo-doctor` shim in mobile dep guard

## Testing
- `npm run lint` (web)
- `npm test` (web)
- `npm run build` (web)
- `npm run align` (mobile)
- `npm test` (mobile)
- `./scripts/local-verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_68bb3546a8f8832fa2a9d3797a5af067