### PR TITLE
chore: add zod runtime deps and tighten audit

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "@supabase/supabase-js": "^2.45.0",
     "localforage": "1.10.0",
     "maplibre-gl": "5.7.0",
+    "zod": "^3.23.8",
     "@thecueroom/ui": "file:../../packages/ui",
     "@thecueroom/schemas": "file:../../packages/schemas"
   },

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "dependencies": {
-    "zod": "3.22.4"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "typescript": "5.4.5"

--- a/scripts/repo-audit.config.mjs
+++ b/scripts/repo-audit.config.mjs
@@ -22,4 +22,16 @@ export const checks = [
   { path: 'apps/mobile/scripts/expo-dep-guard.mjs', mustExist: true }
 ];
 
+checks.push({
+  path: 'packages/schemas/package.json',
+  mustExist: true,
+  regexes: [{ re: '"zod"\\s*:\\s*"[\\^~]?3\\.', flags: 'm', why: 'schemas declares zod' }]
+});
+
+checks.push({
+  path: 'apps/web/package.json',
+  mustExist: true,
+  regexes: [{ re: '"zod"\\s*:\\s*"[\\^~]?3\\.', flags: 'm', why: 'web depends on zod' }]
+});
+
 export default { checks };


### PR DESCRIPTION
## Summary
- add zod to schemas and web runtime deps
- audit for zod in schemas and web
- run mobile align in local verify

## Testing
- `npm run audit`
- `cd apps/web && npm i && npm run build`
- `CI=1 ./scripts/local-verify.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bb4b9c768c832fa79de0738415cafd