### PR TITLE
fix: resolve zod for web build and use expo-doctor fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
           node-version: 20
           cache: 'npm'
           cache-dependency-path: apps/web/package-lock.json
+      - name: Install shared schemas deps
+        working-directory: packages/schemas
+        run: npm ci || npm i
       - run: npm ci || npm i
       - run: npm run lint --if-present
       - run: npm test --if-present

--- a/apps/mobile/scripts/expo-dep-guard.mjs
+++ b/apps/mobile/scripts/expo-dep-guard.mjs
@@ -23,8 +23,15 @@ function checkContains(file, needles) {
   return s;
 }
 
+const doctor = (() => {
+  const tryCmd = (cmd, args) => spawnSync(cmd, args, { stdio: 'pipe' });
+  const a = tryCmd('npx', ['expo-doctor', '--version']);
+  if (a.status === 0) return ['expo-doctor'];      // npx expo-doctor exists
+  return ['expo', 'doctor'];                       // fallback (classic)
+})();
+
 console.log('\n[guard] Expo dependency alignment — start');
-run('npx', ['expo-doctor']);              // official doctor shim
+run('npx', doctor);
 run('npx', ['expo', 'install', '--fix']); // align all managed deps
 run('npx', ['expo', 'install', 'react-native-screens', 'react-native-safe-area-context']); // re-pin
 

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -6,6 +6,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  experimental: {
+    externalDir: true,
+  },
   transpilePackages: ['@thecueroom/ui', '@thecueroom/schemas'],
   outputFileTracingRoot: path.resolve(__dirname, '../../')
 };

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "thecueroom-monorepo",
   "private": true,
   "type": "module",
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
   "scripts": {
     "lint:web": "npm run lint --prefix apps/web",
     "build:web": "npm run build --prefix apps/web",
@@ -16,6 +19,7 @@
     "ci": "npm run lint:packages && npm run lint:web && npm run build:web && npm run test:mobile && npm run lint:mobile",
     "audit": "node scripts/repo-audit.mjs",
     "audit:fix": "node scripts/repo-audit.mjs --fix",
-    "verify": "bash ./scripts/local-verify.sh"
+    "verify": "bash ./scripts/local-verify.sh",
+    "bootstrap:packages": "npm ci --prefix packages/schemas || npm i --prefix packages/schemas"
   }
 }

--- a/scripts/local-verify.sh
+++ b/scripts/local-verify.sh
@@ -70,6 +70,12 @@ fi
 ### --- Web ---
 if [[ -d apps/web ]]; then
   rule "Web: install, lint, test, build"
+  echo "  • Installing shared package deps (packages/schemas)"
+  if [ -f packages/schemas/package-lock.json ]; then
+    npm ci --prefix packages/schemas
+  else
+    npm i --prefix packages/schemas
+  fi
   pushd apps/web >/dev/null
   install_here
   run_if_present "lint"


### PR DESCRIPTION
## Summary
- ensure zod dependency is installed at root and declare bootstrap helper
- allow web app to import external packages and transpile shared schemas
- install schemas deps in CI and local verify; prefer expo-doctor for mobile alignment

## Testing
- `npm i`
- `npm run bootstrap:packages`
- `cd apps/web && npm i && npm run build`
- `./scripts/local-verify.sh`
- `cd apps/mobile && npm run align`


------
https://chatgpt.com/codex/tasks/task_e_68bb564df50c832fb45e37320362da49