### PR TITLE
ci: skip installs for repo audit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: 20, cache: 'npm' }
-      - run: npm ci || npm i
-      # Assemble large assets BEFORE audit so auditor sees required SVGs
+        with:
+          node-version: 20           # ⬅ no cache here (no root lockfile)
       - name: Assemble large assets (optional)
-        run: node scripts/assemble-assets.mjs || true
-      - name: Repo auditor
+        run: node scripts/assemble-assets.ts || true
+      - name: Run repo auditor
         run: node scripts/repo-audit.mjs
   packages:
     needs: repo-audit


### PR DESCRIPTION
## Summary
- drop npm cache and installs from repo-audit job
- run audit directly without preparing lockfile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb60587e74832f9c90bbf71aca0b5f