### PR TITLE
chore: add playwright installer and testing docs

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,9 @@
     "test": "vitest run",
     "build": "next build",
     "start": "next start",
-    "e2e": "playwright test"
+    "e2e": "playwright test",
+    "e2e:ui": "PWDEBUG=1 playwright test",
+    "e2e:ci": "playwright test --reporter=line"
   },
   "dependencies": {
     "class-variance-authority": "0.7.0",

--- a/apps/web/tests/landing.spec.tsx
+++ b/apps/web/tests/landing.spec.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import RootLayout from '@/app/layout';
+import Page from '@/app/page';
+
+describe('landing page', () => {
+  it('renders hero image', () => {
+    // Render within the layout to catch validateDOMNesting warnings early
+    render(
+      <RootLayout>
+        {/* @ts-expect-error children is ReactNode */}
+        <div><Page /></div>
+      </RootLayout> as any
+    );
+    expect(screen.getByAltText(/thecueRoom landing/i)).toBeInTheDocument();
+  });
+});

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,43 @@
+# Testing & E2E
+
+## Quick commands
+```bash
+# audit + route checks
+npm run audit
+npm run scan:placeholders
+node scripts/check-next-routes.mjs
+
+# web unit + e2e
+cd apps/web
+npm test
+npm run build
+npm run e2e         # requires browsers (installed automatically via local-verify)
+cd ../..
+
+# mobile unit
+cd apps/mobile
+npm test
+cd ../..
+```
+
+## Local Playwright setup
+
+macOS/Windows: npx playwright install (done automatically by ./scripts/local-verify.sh).
+
+Linux: npx playwright install --with-deps to install system libraries.
+
+If Playwright complains about missing dependencies, re-run:
+
+node scripts/playwright-install.mjs
+
+## CI behavior
+
+CI uses npx playwright install --with-deps before running E2E.
+
+Web E2E asserts no console.error on pages and checks key routes (/, /feed, /meme-studio, /playlists, /gig-radar).
+
+## Mobile notes
+
+Jest uses jest-expo with mocks for Reanimated, RNGH, Screens, Safe Area, and Expo ESM modules.
+
+We soft-suppress the noisy “not wrapped in act” warning from async query polling; real errors still fail tests.

--- a/scripts/local-verify.sh
+++ b/scripts/local-verify.sh
@@ -80,10 +80,11 @@ else
   warn "apps/web not found; skipping web steps"
 fi
 
-# after building web
+# After web build step
 if [ -f "apps/web/playwright.config.ts" ]; then
-  echo "  • Installing Playwright browsers"
-  (cd apps/web && npx playwright install) || true
+  echo "  • Installing Playwright browsers (platform-aware)"
+  node scripts/playwright-install.mjs || true
+
   echo "  • Running web e2e"
   (cd apps/web && npm run e2e || true)
 fi

--- a/scripts/playwright-install.mjs
+++ b/scripts/playwright-install.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import os from 'node:os';
+
+function run(cmd, args, cwd) {
+  const r = spawnSync(cmd, args, { stdio: 'inherit', cwd });
+  if (r.status !== 0) process.exit(r.status ?? 1);
+}
+
+const platform = os.platform();
+// Always install browsers in apps/web; CI already installs with deps
+const cwd = 'apps/web';
+
+if (platform === 'linux') {
+  // Installs browsers + system deps (headless CI parity)
+  run('npx', ['playwright', 'install', '--with-deps'], cwd);
+} else {
+  // macOS/Windows don’t need apt; standard install is enough
+  run('npx', ['playwright', 'install'], cwd);
+}
+
+console.log('[playwright-install] OK');


### PR DESCRIPTION
## Summary
- add platform-aware Playwright installer
- run Playwright in local verify and add landing smoke test
- document testing workflow

## Testing
- `npm test` (fails: supabase.removeChannel is not a function)
- `npm run build`
- `node scripts/playwright-install.mjs`
- `bash scripts/local-verify.sh` (fails: Inter is not a function)


------
https://chatgpt.com/codex/tasks/task_e_68bb7d163890832fbb802e54d4de133f