### PR TITLE
chore: bootstrap schemas before web build

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,7 +24,7 @@
     "@supabase/supabase-js": "^2.45.0",
     "localforage": "1.10.0",
     "maplibre-gl": "5.7.0",
-    "zod": "^3.23.8",
+    "zod": "3.23.8",
     "@thecueroom/ui": "file:../../packages/ui",
     "@thecueroom/schemas": "file:../../packages/schemas"
   },

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "zod": "^3.23.8"
+    "zod": "3.23.8"
   },
   "scripts": {
     "lint:web": "npm run lint --prefix apps/web",
-    "build:web": "npm run build --prefix apps/web",
+    "build:web": "npm run bootstrap:packages && npm run build --prefix apps/web",
     "lint:mobile": "npm run lint --prefix apps/mobile",
     "test:mobile": "npm run test --prefix apps/mobile",
     "lint:schemas": "npx -y -p typescript@5.4.5 tsc -p packages/schemas/tsconfig.json",

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "dependencies": {
-    "zod": "^3.23.8"
+    "zod": "3.23.8"
   },
   "devDependencies": {
     "typescript": "5.4.5"


### PR DESCRIPTION
## Summary
- pin `zod` to 3.23.8 across the monorepo
- run schema bootstrap before building web app to avoid missing deps

## Testing
- `npm run lint:schemas`
- `npm run lint:web`
- `npm test`
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon npm run build:web`


------
https://chatgpt.com/codex/tasks/task_e_68bc02884040832fbeda0612d9ee908d