### PR TITLE
fix: bootstrap schemas and lazy supabase init

### DIFF
--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -11,18 +11,22 @@ interface SessionContextValue {
 const SessionContext = createContext<SessionContextValue | undefined>(undefined);
 
 export function SessionProvider({ children }: { children: React.ReactNode }) {
-  const supabase = getBrowserClient();
+  const [supabase, setSupabase] = useState<SupabaseClient | null>(null);
   const [session, setSession] = useState<Session | null>(null);
 
   useEffect(() => {
-    supabase.auth.getSession().then(({ data }) => setSession(data.session));
-    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+    const client = getBrowserClient();
+    setSupabase(client);
+    client.auth.getSession().then(({ data }) => setSession(data.session));
+    const { data: listener } = client.auth.onAuthStateChange((_event, session) => {
       setSession(session);
     });
     return () => {
       listener.subscription.unsubscribe();
     };
-  }, [supabase]);
+  }, []);
+
+  if (!supabase) return null;
 
   return (
     <SessionContext.Provider value={{ supabase, session }}>

--- a/apps/web/components/auth/AuthForm.tsx
+++ b/apps/web/components/auth/AuthForm.tsx
@@ -1,16 +1,25 @@
 "use client";
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { getBrowserClient } from '../../lib/supabase-browser';
 
 export default function AuthForm() {
-  const supabase = getBrowserClient();
+  const [supabase, setSupabase] = useState<SupabaseClient | null>(null);
   const [email, setEmail] = useState('');
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  useEffect(() => {
+    setSupabase(getBrowserClient());
+  }, []);
+
   const sendLink = async () => {
+    if (!supabase) return;
     setError(null);
-    const { error } = await supabase.auth.signInWithOtp({ email, options: { emailRedirectTo: `${location.origin}/callback` } });
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: `${location.origin}/callback` }
+    });
     if (error) {
       setError(error.message);
     } else {
@@ -19,7 +28,11 @@ export default function AuthForm() {
   };
 
   const oauth = async (provider: 'google' | 'apple') => {
-    await supabase.auth.signInWithOAuth({ provider, options: { redirectTo: `${location.origin}/callback` } });
+    if (!supabase) return;
+    await supabase.auth.signInWithOAuth({
+      provider,
+      options: { redirectTo: `${location.origin}/callback` }
+    });
   };
 
   return (

--- a/apps/web/components/auth/TOTPSetup.tsx
+++ b/apps/web/components/auth/TOTPSetup.tsx
@@ -1,9 +1,10 @@
 "use client";
 import { useEffect, useState } from 'react';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { getBrowserClient } from '@/lib/supabase-browser';
 
 export default function TOTPSetup() {
-  const supabase = getBrowserClient();
+  const [supabase, setSupabase] = useState<SupabaseClient | null>(null);
   const [qr, setQr] = useState<string | null>(null);
   const [factorId, setFactorId] = useState<string | null>(null);
   const [code, setCode] = useState('');
@@ -11,6 +12,11 @@ export default function TOTPSetup() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    setSupabase(getBrowserClient());
+  }, []);
+
+  useEffect(() => {
+    if (!supabase) return;
     (async () => {
       const { data, error } = await supabase.auth.mfa.enroll({ factorType: 'totp' });
       if (!error && data?.totp) {
@@ -21,7 +27,7 @@ export default function TOTPSetup() {
   }, [supabase]);
 
   const verify = async () => {
-    if (!factorId) return;
+    if (!supabase || !factorId) return;
     const { error } = await supabase.auth.mfa.verify({ factorId, code } as any);
     if (error) {
       setError(error.message);

--- a/apps/web/components/auth/UserMenu.tsx
+++ b/apps/web/components/auth/UserMenu.tsx
@@ -1,19 +1,25 @@
 'use client';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { getBrowserClient } from '@/lib/supabase-browser';
 import { useSession } from '@/app/providers';
 
 export default function UserMenu() {
   const { session } = useSession();
-  const supabase = getBrowserClient();
+  const [supabase, setSupabase] = useState<SupabaseClient | null>(null);
   const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    setSupabase(getBrowserClient());
+  }, []);
 
   if (!session) return null;
   const avatar = session.user.user_metadata?.avatar_url as string | undefined;
   const role = session.user.app_metadata?.role as string | undefined;
 
   const signOut = async () => {
+    if (!supabase) return;
     await supabase.auth.signOut();
     location.href = '/login';
   };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "audit:fix": "node scripts/repo-audit.mjs --fix",
     "scan:placeholders": "node scripts/no-placeholders.mjs",
     "verify:local": "bash ./scripts/local-verify.sh",
-    "bootstrap:packages": "npm ci --prefix packages/schemas || npm i --prefix packages/schemas"
+    "bootstrap:packages": "npm --prefix packages/schemas ci --no-audit --no-fund || npm --prefix packages/schemas i --no-audit --no-fund"
   }
 }

--- a/packages/schemas/package-lock.json
+++ b/packages/schemas/package-lock.json
@@ -1,0 +1,39 @@
+{
+  "name": "@thecueroom/schemas",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@thecueroom/schemas",
+      "dependencies": {
+        "zod": "3.23.8"
+      },
+      "devDependencies": {
+        "typescript": "5.4.5"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- fix bootstrap script to install schemas dependencies correctly
- defer Supabase client creation in client components to allow building without env vars
- add missing package-lock for schemas package

## Testing
- `npm run lint:web`
- `npm --prefix apps/web run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc1ed96560832f8708b76188af9bc3