### PR TITLE
chore: pin zod and install via workspaces in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
   web:
     needs: repo-audit
     runs-on: ubuntu-latest
-    defaults: { run: { working-directory: apps/web } }
     env:
       NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL }}
       NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
@@ -45,19 +44,19 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: apps/web/package-lock.json
+          # cache both root and app locks if present
+          cache-dependency-path: |
+            package-lock.json
+            apps/web/package-lock.json
 
-      # Try ci first; if the lock is out-of-sync, fall back to a normal install.
-      - name: Install deps (ci with fallback)
-        working-directory: apps/web
+      # Install at repo root with workspaces so shared package deps (like zod) are available
+      - name: Install (ci with fallback) at root
         run: |
-          npm ci || (echo "npm ci failed, falling back to npm i" && npm i --no-audit --no-fund)
+          npm ci --workspaces || (echo "npm ci failed; falling back to npm i" && npm i --workspaces --no-audit --no-fund)
 
-      # Double-ensure zod is present in case of future drift
-      - name: Verify zod
-        working-directory: apps/web
-        run: |
-          npm ls zod || npm i zod@3.25.76 --no-audit --no-fund
+      # Verify web can resolve zod before attempting Next build
+      - name: Verify web deps
+        run: node scripts/verify-web-deps.mjs
 
       - name: Build web
         working-directory: apps/web

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -17,7 +17,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "tailwind-merge": "1.14.0",
-        "zod": "^3.23.8"
+        "zod": "3.25.76"
       },
       "devDependencies": {
         "@playwright/test": "^1.47.2",
@@ -43,7 +43,7 @@
     "../../packages/schemas": {
       "name": "@thecueroom/schemas",
       "dependencies": {
-        "zod": "^3.23.8"
+        "zod": "3.25.76"
       },
       "devDependencies": {
         "typescript": "5.4.5"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "check:deps": "node ../../scripts/verify-web-deps.mjs",
     "dev": "next dev",
     "lint": "eslint --ext .ts,.tsx .",
     "test": "vitest run",

--- a/packages/schemas/package-lock.json
+++ b/packages/schemas/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "@thecueroom/schemas",
       "dependencies": {
-        "zod": "3.23.8"
+        "zod": "3.25.76"
       },
       "devDependencies": {
         "typescript": "5.4.5"
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "dependencies": {
-    "zod": "3.23.8"
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "typescript": "5.4.5"

--- a/scripts/verify-web-deps.mjs
+++ b/scripts/verify-web-deps.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+import { createRequire } from 'module';
+import path from 'node:path';
+import process from 'node:process';
+
+const req = createRequire(path.resolve('apps/web/package.json'));
+function mustResolve(mod) {
+  try {
+    req.resolve(mod);
+    console.log(`[deps] OK: ${mod}`);
+  } catch (e) {
+    console.error(`[deps] MISSING: ${mod}`);
+    process.exit(1);
+  }
+}
+mustResolve('zod');


### PR DESCRIPTION
## Summary
- pin zod@3.25.76 for schemas and web packages
- add dep verification script for web
- install via npm workspaces and verify deps in CI before building

## Testing
- `node scripts/verify-web-deps.mjs`
- `npm run build --prefix apps/web`

------
https://chatgpt.com/codex/tasks/task_e_68bc24e8b734832f9617d163d4788f35