### PR TITLE
fix(web): install schemas deps before build

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "lint": "eslint --ext .ts,.tsx .",
     "test": "vitest run",
+    "prebuild": "npm --prefix ../../packages/schemas ci --no-audit --no-fund || npm --prefix ../../packages/schemas i --no-audit --no-fund",
     "build": "next build",
     "build:static": "STATIC_EXPORT=1 next build && next export -o out",
     "preview:static": "npx http-server ./out -p 4173 -c-1 --silent",


### PR DESCRIPTION
## Summary
- ensure `apps/web` installs `packages/schemas` dependencies before building to avoid missing `zod`

## Testing
- `npm run lint --prefix apps/web`
- `npm run build --prefix apps/web`


------
https://chatgpt.com/codex/tasks/task_e_68bc2a506c54832f89290996d0d22aaf