### PR TITLE
fix: install schema deps before static export

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "test": "vitest run",
     "prebuild": "npm --prefix ../../packages/schemas ci --no-audit --no-fund || npm --prefix ../../packages/schemas i --no-audit --no-fund",
     "build": "next build",
-    "build:static": "STATIC_EXPORT=1 next build && next export -o out",
+    "build:static": "npm run prebuild && STATIC_EXPORT=1 next build",
     "preview:static": "npx http-server ./out -p 4173 -c-1 --silent",
     "start": "next start",
     "e2e": "playwright test",


### PR DESCRIPTION
## Summary
- ensure web's static build installs schemas package dependencies
- rely on Next 15's built-in static export instead of deprecated `next export`

## Testing
- `CI=1 npm run build:static --prefix apps/web`
- `npm test --prefix apps/web`
- `npm run lint --prefix apps/web`

------
https://chatgpt.com/codex/tasks/task_e_68bc810125bc832fa9642497c06b6e69