### PR TITLE
feat: revamp landing page copy and UX

### DIFF
--- a/apps/web/app/(marketing)/page.tsx
+++ b/apps/web/app/(marketing)/page.tsx
@@ -1,7 +1,9 @@
 'use client';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import Logo from '@/components/Logo';
 import UserMenu from '@/components/auth/UserMenu';
+import LoginDialog from '@/components/auth/LoginDialog';
 import Hero from '@/components/landing/Hero';
 import FeatureGrid from '@/components/landing/FeatureGrid';
 import FeedPreview from '@/components/landing/FeedPreview';
@@ -15,6 +17,17 @@ export const dynamic = 'force-dynamic';
 
 function Content() {
   const { session } = useSession();
+  const [open, setOpen] = useState(false);
+  const [showSticky, setShowSticky] = useState(false);
+
+  useEffect(() => {
+    function onScroll() {
+      setShowSticky(window.scrollY > 300);
+    }
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
   return (
     <>
       <header className="py-6">
@@ -23,25 +36,42 @@ function Content() {
           {session ? (
             <UserMenu />
           ) : (
-            <Link
-              href="/login"
-              className="rounded bg-lime px-4 py-2 font-bold text-black"
-            >
-              Login / Sign Up
-            </Link>
+            <div className="relative group">
+              <button
+                onClick={() => setOpen(true)}
+                className="rounded bg-lime px-4 py-2 font-bold text-black transition-transform hover:scale-105 hover:brightness-110"
+              >
+                Join Free
+              </button>
+              <div className="absolute right-0 mt-2 hidden w-56 rounded bg-surface p-2 text-xs text-muted shadow group-hover:block">
+                <p>Email magic link — no password</p>
+                <p className="mt-1 flex items-center gap-1 text-[10px]">
+                  <span aria-hidden>🔒</span>Invite-only • Verified community
+                </p>
+              </div>
+            </div>
           )}
         </div>
       </header>
       <main>
-        <Hero />
+        <Hero onJoinClick={() => setOpen(true)} />
         <FeatureGrid />
         <div className="mx-auto max-w-[1200px] px-6 py-24 md:grid md:grid-cols-2 md:gap-8">
           <FeedPreview />
           <HowItWorks />
         </div>
-        <CtaBand />
+        <CtaBand onJoinClick={() => setOpen(true)} />
       </main>
       <Footer />
+      {!session && showSticky && (
+        <button
+          onClick={() => setOpen(true)}
+          className="fixed bottom-4 right-4 z-50 rounded-full bg-lime px-4 py-2 text-sm font-bold text-black shadow-lg transition-transform hover:scale-105 hover:brightness-110 md:hidden"
+        >
+          Join Free
+        </button>
+      )}
+      <LoginDialog open={open} onClose={() => setOpen(false)} />
     </>
   );
 }

--- a/apps/web/components/auth/LoginDialog.tsx
+++ b/apps/web/components/auth/LoginDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { getBrowserClient } from '@/lib/supabase-browser';
 
 export default function LoginDialog({
@@ -10,15 +10,34 @@ export default function LoginDialog({
   const supabase = getBrowserClient();
   const [email, setEmail] = useState('');
   const [sent, setSent] = useState(false);
+  const [resendReady, setResendReady] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+
+  async function sendLink() {
+    const { error } = await supabase.auth.signInWithOtp({ email });
+    if (error) setErr(error.message);
+    else {
+      setSent(true);
+      setResendReady(false);
+    }
+  }
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
     setErr(null);
-    const { error } = await supabase.auth.signInWithOtp({ email });
-    if (error) setErr(error.message);
-    else setSent(true);
+    await sendLink();
   }
+
+  async function onResend() {
+    setErr(null);
+    await sendLink();
+  }
+
+  useEffect(() => {
+    if (!sent) return;
+    const id = setTimeout(() => setResendReady(true), 30000);
+    return () => clearTimeout(id);
+  }, [sent]);
 
   if (!open) return null;
   return (
@@ -35,9 +54,19 @@ export default function LoginDialog({
           </button>
         </div>
         {sent ? (
-          <p className="mt-4 text-zinc-300">
-            Magic link sent! Check your inbox on this device. Keep this tab open.
-          </p>
+          <div className="mt-4 text-zinc-300">
+            <p>
+              Magic link sent to {email}. Check your inbox at {email.split('@')[1]}.
+            </p>
+            {resendReady && (
+              <button
+                onClick={onResend}
+                className="mt-4 w-full rounded-lg bg-[var(--lime)] px-4 py-2 font-medium text-black hover:opacity-90"
+              >
+                Resend
+              </button>
+            )}
+          </div>
         ) : (
           <form onSubmit={onSubmit} className="mt-4 space-y-3">
             <label className="block text-sm text-zinc-300">

--- a/apps/web/components/landing/CtaBand.tsx
+++ b/apps/web/components/landing/CtaBand.tsx
@@ -1,27 +1,27 @@
 import Link from 'next/link';
 
-export default function CtaBand() {
+export default function CtaBand({ onJoinClick }: { onJoinClick: () => void }) {
   return (
     <section className="mx-auto max-w-[1200px] px-6 py-24" aria-labelledby="cta-heading">
       <div className="rounded-md bg-surface p-8 text-center shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)]">
         <h2 id="cta-heading" className="text-2xl font-bold">
-          Ready to dive in?
+          Ready to plug into the underground?
         </h2>
         <p className="mt-2 text-muted">
-          Join the community or learn more about our platform.
+          Join the community, build your profile, and get seen by the right people.
         </p>
         <div className="mt-6 flex justify-center gap-4">
-          <Link
-            href="/signup"
-            className="rounded bg-lime px-6 py-3 font-bold text-black focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lime"
+          <button
+            onClick={onJoinClick}
+            className="rounded bg-lime px-6 py-3 font-bold text-black transition-transform hover:scale-105 hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lime"
           >
-            Join the Community
-          </Link>
+            Join Free — Get Magic Link
+          </button>
           <Link
-            href="#learn-more"
-            className="rounded border border-lime px-6 py-3 font-bold text-lime focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lime"
+            href="#how-it-works"
+            className="rounded border border-lime px-6 py-3 font-bold text-lime transition-transform hover:scale-105 hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lime"
           >
-            Learn More
+            See How It Works
           </Link>
         </div>
       </div>

--- a/apps/web/components/landing/FeatureGrid.tsx
+++ b/apps/web/components/landing/FeatureGrid.tsx
@@ -2,28 +2,36 @@ import Card from './Card';
 
 const features = [
   {
-    title: 'Curated Community',
-    body: 'Join a vetted network of underground artists and fans.',
+    title: 'AI Cover Art',
+    body: 'Ship on-brand covers from vibe + genre in under a minute. Full-res exports—yours to use.',
   },
   {
-    title: 'Real-Time Feed',
-    body: 'Stay updated with the latest drops and discussions.',
+    title: 'Meme Studio',
+    body: 'Turn moments (or an optional image) into shareable, on-brand memes that actually get reposted.',
   },
   {
-    title: 'Event Radar',
-    body: 'Discover gigs and meetups tailored to your taste.',
+    title: 'Artist Verification',
+    body: 'Vetted profiles and invite flow help you avoid fakes and spam. Look credible when you pitch.',
   },
   {
-    title: 'Collaborative Playlists',
-    body: 'Build and share mixes with the community.',
+    title: 'Private & Tiered Access',
+    body: 'Verified-first spaces, content flags, and mod tools keep the feed useful—and the culture clean.',
   },
   {
-    title: 'AI Tools',
-    body: 'Leverage machine learning to surface hidden gems.',
+    title: 'Curated News Rail',
+    body: 'Underground sources only. No SEO sludge. Scene-relevant drops for your region.',
   },
   {
-    title: 'Secure Profiles',
-    body: 'Own your identity with privacy-first accounts.',
+    title: 'Gig Radar',
+    body: 'Find and promote events. Filter by city/region and DM promoters who are open to pitches.',
+  },
+  {
+    title: 'Creator Dashboard',
+    body: 'One place for your EPK, stage plot, links, and posts. Share a single link that stays current.',
+  },
+  {
+    title: 'Invite-Only Community',
+    body: 'Built for serious techno/house creators. Fewer tourists, more people who actually ship.',
   },
 ];
 

--- a/apps/web/components/landing/FeedPreview.tsx
+++ b/apps/web/components/landing/FeedPreview.tsx
@@ -1,7 +1,7 @@
 const lines = [
-  'Members share underground finds daily.',
-  'Vote and comment to surface the best.',
-  'Follow threads from your favorite creators.',
+  '"New live set—jungle rollers recorded in Mana Rainforest."',
+  '"Looking for lighting tech for Saturday’s gig — DM me."',
+  '"Posted a deep-night drive mix at 128 BPM."',
 ];
 
 export default function FeedPreview() {
@@ -11,12 +11,14 @@ export default function FeedPreview() {
       aria-labelledby="feed-preview-heading"
     >
       <h2 id="feed-preview-heading" className="mb-4 text-base font-semibold">
-        Community Feed Preview
+        A vetted feed—no spam, no bots. What members are posting:
       </h2>
       <ul className="space-y-2">
         {lines.map((line) => (
           <li key={line} className="flex items-start gap-2">
-            <span className="mt-1 h-2 w-2 flex-none bg-lime" />
+            <span className="mt-0.5 flex h-3 w-3 flex-none items-center justify-center rounded-full bg-lime text-[8px] text-black">
+              ✓
+            </span>
             <span className="text-sm text-muted">{line}</span>
           </li>
         ))}

--- a/apps/web/components/landing/Footer.tsx
+++ b/apps/web/components/landing/Footer.tsx
@@ -38,9 +38,15 @@ export default function Footer() {
         Footer
       </h2>
       <div className="mx-auto flex max-w-[1200px] flex-col items-start justify-between gap-8 px-6 py-12 md:flex-row">
-        <p className="text-xs text-muted">
-          © TheCueRoom {new Date().getFullYear()} – All rights reserved.
-        </p>
+        <div className="max-w-xs">
+          <p className="text-sm italic text-purple">
+            Where music meets machine, and the underground stays pure.
+          </p>
+          <p className="mt-1 text-[10px] text-muted">No spam. Unsubscribe anytime.</p>
+          <p className="mt-4 text-xs text-muted">
+            © TheCueRoom {new Date().getFullYear()} – All rights reserved.
+          </p>
+        </div>
         <nav className="grid flex-1 grid-cols-2 gap-8 sm:grid-cols-4">
           {columns.map((col) => (
             <div key={col.title}>

--- a/apps/web/components/landing/Hero.tsx
+++ b/apps/web/components/landing/Hero.tsx
@@ -3,29 +3,29 @@
 import Link from 'next/link';
 import Bloom from './Bloom';
 
-export default function Hero() {
+export default function Hero({ onJoinClick }: { onJoinClick: () => void }) {
   return (
     <section className="relative mx-auto max-w-[1200px] px-6 py-24 text-center">
       <Bloom />
-      <h1 className="heading-1">Welcome to thecueRoom</h1>
+      <h1 className="heading-1">Book gigs. Look legit. Create faster.</h1>
       <p className="text-muted mx-auto mt-4 max-w-2xl">
-        Discover the next wave of underground music powered by community and tech.
+        An invite-only studio and community for underground techno & house artists. Generate release-ready art, get verified to avoid scams, and tap a vetted feed of gigs, news, and collaborators.
       </p>
       <p className="mt-2 italic text-purple">
         Where music meets machine, and the underground stays pure.
       </p>
       <div className="mt-8 flex items-center justify-center gap-4">
-        <Link
-          href="/signup"
-          className="flex h-11 items-center rounded bg-lime px-6 font-bold text-black"
+        <button
+          onClick={onJoinClick}
+          className="flex h-11 items-center rounded bg-lime px-6 font-bold text-black transition-transform hover:scale-105 hover:brightness-110"
         >
-          Join the Community
-        </Link>
+          Join Free — Get Magic Link
+        </button>
         <Link
-          href="#learn-more"
-          className="flex h-11 items-center rounded border border-lime px-6 font-bold text-lime"
+          href="#how-it-works"
+          className="flex h-11 items-center rounded border border-lime px-6 font-bold text-lime transition-transform hover:scale-105 hover:brightness-110"
         >
-          Learn More
+          See How It Works
         </Link>
       </div>
       <div className="mt-16">

--- a/apps/web/components/landing/HowItWorks.tsx
+++ b/apps/web/components/landing/HowItWorks.tsx
@@ -1,13 +1,14 @@
 const steps = [
-  'Sign up and create your profile.',
-  'Explore the feed and follow creators.',
-  'Share your finds and join discussions.',
-  'Attend events and grow your network.',
+  'Apply or get invited by verified members (about 60 seconds).',
+  'Build your EPK & stage plot once—share a single link everywhere.',
+  'Post, discover gigs & collaborators, and reply without the noise.',
+  'Tune your feed by genre, region, and intent (networking, bookings, feedback).',
+  'Free to join. You keep your rights.',
 ];
 
 export default function HowItWorks() {
   return (
-    <section aria-labelledby="how-it-works-heading">
+    <section id="how-it-works" aria-labelledby="how-it-works-heading">
       <h2 id="how-it-works-heading" className="mb-4 text-base font-semibold">
         How TheCueRoom Works
       </h2>


### PR DESCRIPTION
## Summary
- rewrite marketing hero, feature grid, feed, and CTA bands with conversion-focused copy
- add magic link tooltip, sticky mobile join button, and login dialog resend flow
- include micro-trust footer note and invite-only messaging

## Testing
- `npm run lint:web`
- `npm run test:web`
- `npm run build:web`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bca2672df4832fa47aac35c44a50f9