### PR TITLE
fix: guard playlists fetch return type

### DIFF
--- a/apps/web/app/(music)/playlists/page.tsx
+++ b/apps/web/app/(music)/playlists/page.tsx
@@ -31,7 +31,7 @@ async function fetchPlaylists(): Promise<Playlist[]> {
       { headers: { apikey: key, Authorization: `Bearer ${key}` }, cache: 'no-store' }
     );
     const data = await res.json();
-    return (data as Playlist[]) ?? FALLBACK;
+    return Array.isArray(data) ? (data as Playlist[]) : FALLBACK;
   } catch {
     return FALLBACK;
   }


### PR DESCRIPTION
## Summary
- ensure playlists fetch returns an array before mapping

## Testing
- `npm run lint:web`
- `cd apps/web && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bca5acb7c4832f89ea105b3f83e0ae