### PR TITLE
fix(web): install schema deps for static build

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "lint": "eslint --ext .ts,.tsx .",
     "test": "vitest run",
     "prebuild": "npm --prefix ../../packages/schemas ci --no-audit --no-fund || npm --prefix ../../packages/schemas i --no-audit --no-fund",
+    "prebuild:static": "npm --prefix ../../packages/schemas ci --no-audit --no-fund || npm --prefix ../../packages/schemas i --no-audit --no-fund",
     "build": "next build",
     "build:static": "STATIC_EXPORT=1 next build && next export -o out",
     "preview:static": "npx http-server ./out -p 4173 -c-1 --silent",


### PR DESCRIPTION
## Summary
- ensure `build:static` installs `@thecueroom/schemas` dependencies

## Testing
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build:static`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcac48a9e8832fb49810733df9f451