### PR TITLE
fix: use next build only for static export

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,7 @@
     "prebuild": "npm --prefix ../../packages/schemas ci --no-audit --no-fund || npm --prefix ../../packages/schemas i --no-audit --no-fund",
     "prebuild:static": "npm --prefix ../../packages/schemas ci --no-audit --no-fund || npm --prefix ../../packages/schemas i --no-audit --no-fund",
     "build": "next build",
-    "build:static": "STATIC_EXPORT=1 next build && next export -o out",
+    "build:static": "STATIC_EXPORT=1 next build",
     "preview:static": "npx http-server ./out -p 4173 -c-1 --silent",
     "start": "next start",
     "e2e": "playwright test",


### PR DESCRIPTION
## Summary
- fix build:static script to use `next build` since `next export` is removed in Next 15

## Testing
- `npm test`
- `npm run lint:web`


------
https://chatgpt.com/codex/tasks/task_e_68bcb0f40550832fbd5d1926efdd67f4