### PR TITLE
chore: add root build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "tsx": "4.7.1"
   },
   "scripts": {
+    "build": "npm run build:web",
     "lint:web": "npm run lint --prefix apps/web",
     "build:web": "npm run bootstrap:packages && npm run build --prefix apps/web",
     "lint:mobile": "npm run lint --prefix apps/mobile",


### PR DESCRIPTION
## Summary
- add root `build` script to invoke web app build

## Testing
- `npm run build`
- `npm test`
- `npm run lint:web`


------
https://chatgpt.com/codex/tasks/task_e_68bdf06a6914832fa51784d09a491409