### PR TITLE
fix: install web dependencies before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "npm run build:web",
     "lint:web": "npm run lint --prefix apps/web",
-    "build:web": "npm run bootstrap:packages && npm run build --prefix apps/web",
+    "build:web": "npm run bootstrap:packages && (npm --prefix apps/web ci --no-audit --no-fund || npm --prefix apps/web i --no-audit --no-fund) && npm run build --prefix apps/web",
     "lint:mobile": "npm run lint --prefix apps/mobile",
     "test:mobile": "npm run test --prefix apps/mobile",
     "lint:schemas": "npx -y -p typescript@5.4.5 tsc -p packages/schemas/tsconfig.json",


### PR DESCRIPTION
## Summary
- ensure apps/web dependencies are installed before building

## Testing
- `npm install`
- `npm run build:web`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf262b8d4832fa6df045976ac3d1a