### PR TITLE
fix: update site metadata for GitHub Pages

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,6 +3,8 @@ import { Inter, Source_Code_Pro } from 'next/font/google';
 import type { ReactNode } from 'react';
 import AuthHashRouter from '@/components/AuthHashRouter';
 
+export { metadata } from './metadata';
+
 const inter = Inter({ subsets: ['latin'] });
 const sourceCode = Source_Code_Pro({ subsets: ['latin'], variable: '--font-mono' });
 

--- a/apps/web/app/metadata.ts
+++ b/apps/web/app/metadata.ts
@@ -1,8 +1,12 @@
 import type { Metadata } from 'next';
-const site = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+
+const site =
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  'https://dejayillegal.github.io/thecueRoom_V2APP';
 
 export const metadata: Metadata = {
   metadataBase: new URL(site),
   title: 'thecueRoom',
-  description: '…',
+  description:
+    'A social playground for cues, built with a Vite/React web app, Expo mobile app, and Node/Express + Drizzle backend.',
 };


### PR DESCRIPTION
## Summary
- set default site url for metadata to the GitHub Pages address
- expose metadata from root layout so Next.js uses it

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdf5147500832fb7384f3d488e4c51