### PR TITLE
Configure CI/CD workflows and Next.js base path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,107 @@
 name: CI
-on: [push, pull_request]
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
+  verify:
     runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+      NEXT_PUBLIC_BASE_PATH: ${{ vars.NEXT_PUBLIC_BASE_PATH }}
+      NEXT_TELEMETRY_DISABLED: ${{ vars.NEXT_TELEMETRY_DISABLED }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+
+      - name: Use Node 20
+        uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm install
-      - run: npm run build
+          cache: npm
+
+      # ----- Root audit + placeholder scan
+      - name: Install root (if needed for scripts)
+        run: npm ci --no-audit --no-fund || npm i --no-audit --no-fund
+
+      - name: Repo audit
+        run: |
+          npm run audit
+          npm run scan:placeholders
+          node scripts/check-next-routes.mjs
+
+      # ----- Web: install, unit tests, playwright
+      - name: Cache web node_modules
+        uses: actions/cache@v4
+        with:
+          path: apps/web/node_modules
+          key: web-${{ runner.os }}-${{ hashFiles('apps/web/package-lock.json') }}
+
+      - name: Install web deps
+        working-directory: apps/web
+        run: npm ci --no-audit --no-fund || npm i --no-audit --no-fund
+
+      - name: Type check (web)
+        working-directory: apps/web
+        run: npx tsc -p .
+
+      - name: Web unit tests
+        working-directory: apps/web
+        run: npm test --silent
+
+      - name: Install Playwright browsers + deps
+        run: node scripts/playwright-install.mjs
+
+      - name: Web E2E (headless)
+        working-directory: apps/web
+        run: npm run e2e
+        env:
+          # baseURL if your tests need it; many just use `page.goto('/')`
+          BASE_URL: http://localhost:4173
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: apps/web/playwright-report/
+          if-no-files-found: ignore
+
+      # ----- Build static web (also feeds deploy workflow via artifact)
+      - name: Build web (static export)
+        working-directory: apps/web
+        run: npm run build:static
+
+      - name: Upload web static artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/web/out
+
+      # ----- Mobile: install + tests (no heavy native builds here)
+      - name: Cache mobile node_modules
+        uses: actions/cache@v4
+        with:
+          path: apps/mobile/node_modules
+          key: mobile-${{ runner.os }}-${{ hashFiles('apps/mobile/package-lock.json') }}
+
+      - name: Install mobile deps
+        working-directory: apps/mobile
+        run: npm ci --no-audit --no-fund || npm i --no-audit --no-fund
+
+      - name: Expo dependency guard (doctor with fallback)
+        working-directory: apps/mobile
+        run: node scripts/expo-dep-guard.mjs --ci || node scripts/expo-dep-guard.mjs --ci --fallback
+
+      - name: Mobile Jest
+        working-directory: apps/mobile
+        run: npm test --silent

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,39 @@
+name: Deploy GitHub Pages
+
+on:
+  workflow_run:
+    workflows: [ "CI" ]
+    types: [ completed ]
+    branches: [ main ]
+
+permissions:
+  pages: write
+  id-token: write
+  contents: read
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Download artifact from CI
+        uses: actions/download-artifact@v4
+        with:
+          name: github-pages
+          path: ./out
+      - name: Upload artifact to Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+      - name: Deploy to Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -1,0 +1,69 @@
+name: Expo EAS Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: "android | ios | all"
+        required: true
+        default: "android"
+  push:
+    tags:
+      - "mobile-v*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: eas-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  eas:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/mobile
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      EXPO_PUBLIC_SUPABASE_URL: ${{ vars.EXPO_PUBLIC_SUPABASE_URL }}
+      EXPO_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.EXPO_PUBLIC_SUPABASE_ANON_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/mobile/package-lock.json
+
+      - name: Install deps
+        run: npm ci --no-audit --no-fund
+
+      - name: Lint & test
+        run: |
+          node scripts/expo-dep-guard.mjs --ci || node scripts/expo-dep-guard.mjs --ci --fallback
+          npm test --silent
+
+      - name: Install EAS
+        run: npm i -g eas-cli
+
+      - name: EAS build (cloud)
+        run: |
+          PLATFORM="${{ github.event.inputs.platform || 'android' }}"
+          if [ "$PLATFORM" = "all" ]; then
+            eas build --platform android --profile preview --non-interactive
+            eas build --platform ios --profile preview --non-interactive
+          else
+            eas build --platform "$PLATFORM" --profile preview --non-interactive
+          fi
+
+      - name: Summarize build details
+        run: eas build:list --json --limit 5 | tee /tmp/eas-builds.json
+
+      - name: Upload EAS metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: eas-builds
+          path: /tmp/eas-builds.json

--- a/.github/workflows/supabase-functions.yml
+++ b/.github/workflows/supabase-functions.yml
@@ -1,0 +1,34 @@
+name: Supabase Functions
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "functions/**"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Deploy functions (verifyArtist etc.)
+        working-directory: functions
+        run: |
+          supabase functions deploy verifyArtist --project-ref $SUPABASE_PROJECT_REF --no-verify-jwt
+          # deploy others if you like:
+          # for f in ingestNews ingestTracks moderationHook recommendGigs ; do
+          #   supabase functions deploy "$f" --project-ref $SUPABASE_PROJECT_REF --no-verify-jwt
+          # done

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,10 +1,10 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  output: 'export',
-  basePath: process.env.NEXT_PUBLIC_BASE_PATH || '',
-  assetPrefix: process.env.NEXT_PUBLIC_BASE_PATH || '',
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+
+export default {
+  output: "export",
+  basePath,
+  assetPrefix: basePath ? `${basePath}/` : undefined,
   images: { unoptimized: true },
-  // (optional, removes warnings)
-  // experimental: { typedRoutes: true },
+  experimental: { outputFileTracingRoot: process.cwd() },
 };
-export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,7 @@
     "prebuild": "npm --prefix ../../packages/schemas ci --no-audit --no-fund || npm --prefix ../../packages/schemas i --no-audit --no-fund",
     "prebuild:static": "npm --prefix ../../packages/schemas ci --no-audit --no-fund || npm --prefix ../../packages/schemas i --no-audit --no-fund",
     "build": "next build",
-    "build:static": "STATIC_EXPORT=1 next build",
+    "build:static": "STATIC_EXPORT=1 next build && next export -o out",
     "preview:static": "npx http-server ./out -p 4173 -c-1 --silent",
     "start": "next start",
     "e2e": "playwright test",

--- a/apps/web/tests/landing.spec.tsx
+++ b/apps/web/tests/landing.spec.tsx
@@ -10,7 +10,7 @@ describe('Landing', () => {
   });
   it('renders the raw SVG logo inline', () => {
     render(<Landing />);
-    const logo = screen.getByLabelText(/thecueRoom logo/i) as SVGElement;
+    const logo = screen.getByLabelText(/thecueRoom logo/i) as unknown as SVGElement;
     expect(logo.tagName.toLowerCase()).toBe('svg');
     expect(logo.querySelector('#blinkPath')).not.toBeNull();
   });


### PR DESCRIPTION
## Summary
- add comprehensive CI pipeline with audits, tests, static build and artifacts
- configure GitHub Pages deployment workflow
- add Expo EAS build and optional Supabase functions workflows
- update Next.js basePath handling and static export script
- fix landing test type cast

## Testing
- `npx tsc -p .`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68bdf9d0e798832fa57cc0b885471aad