### PR TITLE
ci: skip deploy jobs without secrets

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   eas:
+    if: ${{ secrets.EXPO_TOKEN != '' }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/supabase-functions.yml
+++ b/.github/workflows/supabase-functions.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   deploy:
+    if: ${{ secrets.SUPABASE_ACCESS_TOKEN != '' && secrets.SUPABASE_PROJECT_REF != '' }}
     runs-on: ubuntu-latest
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- avoid Expo EAS build when `EXPO_TOKEN` secret missing
- skip Supabase function deployment unless required secrets are provided

## Testing
- `npm run test --prefix apps/mobile`

------
https://chatgpt.com/codex/tasks/task_e_68bdfcf1ff30832f8bf61edb5180058d