### PR TITLE
Fix Playwright e2e setup

### DIFF
--- a/apps/web/e2e/landing.spec.ts
+++ b/apps/web/e2e/landing.spec.ts
@@ -7,5 +7,5 @@ test('header logo renders with exact svg + hero image loads', async ({ page }) =
 
   const img = page.locator('img[alt="TheCueRoom marketing landing"]');
   await expect(img).toBeVisible();
-  await expect(await img.evaluate((el: HTMLImageElement) => el.naturalWidth > 0)).resolves.toBeTruthy();
+  await expect(img.evaluate((el: HTMLImageElement) => el.naturalWidth > 0)).resolves.toBeTruthy();
 });

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,10 +1,11 @@
 /** @type {import('next').NextConfig} */
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
 
+const isStaticExport = Boolean(process.env.STATIC_EXPORT);
+
 export default {
-  output: "export",
+  ...(isStaticExport ? { output: "export", images: { unoptimized: true } } : {}),
   basePath,
   assetPrefix: basePath ? `${basePath}/` : undefined,
-  images: { unoptimized: true },
-  experimental: { outputFileTracingRoot: process.cwd() },
+  outputFileTracingRoot: process.cwd(),
 };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,12 +9,12 @@
     "prebuild": "npm --prefix ../../packages/schemas ci --no-audit --no-fund || npm --prefix ../../packages/schemas i --no-audit --no-fund",
     "prebuild:static": "npm --prefix ../../packages/schemas ci --no-audit --no-fund || npm --prefix ../../packages/schemas i --no-audit --no-fund",
     "build": "next build",
-    "build:static": "STATIC_EXPORT=1 next build && next export -o out",
+    "build:static": "STATIC_EXPORT=1 next build",
     "preview:static": "npx http-server ./out -p 4173 -c-1 --silent",
     "start": "next start",
-    "e2e": "playwright test",
-    "e2e:ui": "PWDEBUG=1 playwright test",
-    "e2e:ci": "playwright test --reporter=line"
+    "e2e": "npm run build && npx playwright install --with-deps && playwright test",
+    "e2e:ui": "npm run build && npx playwright install --with-deps && PWDEBUG=1 playwright test",
+    "e2e:ci": "npm run build && npx playwright install --with-deps && playwright test --reporter=line"
   },
   "dependencies": {
     "class-variance-authority": "0.7.0",


### PR DESCRIPTION
## Summary
- allow Next.js to serve dynamically unless `STATIC_EXPORT` is set and move `outputFileTracingRoot` to top-level
- ensure e2e script builds app, installs Playwright browsers, and runs tests
- fix landing page image assertion

## Testing
- `npm run lint`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68be01cab128832fb3a672af37273730