### PR TITLE
fix: ensure Playwright webServer binds to IPv4

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -7,13 +7,13 @@ export default defineConfig({
   retries: 0,
   reporter: 'list',
   use: {
-    baseURL: process.env.PW_BASE_URL || 'http://localhost:3000',
+    baseURL: process.env.PW_BASE_URL || 'http://127.0.0.1:3000',
     trace: 'retain-on-failure',
     viewport: { width: 1366, height: 900 },
   },
   webServer: {
-    command: 'npm run start',
-    url: 'http://localhost:3000',
+    command: 'npm run start -- --hostname 127.0.0.1',
+    url: 'http://127.0.0.1:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
   },


### PR DESCRIPTION
## Summary
- use 127.0.0.1 for Playwright webServer and baseURL

## Testing
- `npm run lint:web`
- `npm run test:web`
- `cd apps/web && npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68be09ac739c832f8614fde13d709b76