### PR TITLE
fix: add Deno type stubs for edge functions

### DIFF
--- a/functions/deno-stubs.d.ts
+++ b/functions/deno-stubs.d.ts
@@ -1,0 +1,29 @@
+declare const Deno: {
+  env: { get(key: string): string | undefined };
+  test: (name: string, fn: () => void | Promise<void>) => void;
+};
+
+interface ImportMeta {
+  main?: boolean;
+}
+
+declare module "https://deno.land/std@0.203.0/http/server.ts" {
+  export function serve(
+    handler: (req: Request) => Response | Promise<Response>,
+  ): void;
+}
+
+declare module "std/testing/asserts.ts" {
+  export function assertEquals<T>(actual: T, expected: T, message?: string): void;
+}
+
+declare module "npm:@supabase/supabase-js@2.42.0" {
+  export function createClient(url: string, key: string): any;
+}
+
+declare module "npm:fast-xml-parser@4.2.7" {
+  export class XMLParser {
+    constructor(opts?: unknown);
+    parse(xml: string): any;
+  }
+}

--- a/functions/ingestNews/index_test.ts
+++ b/functions/ingestNews/index_test.ts
@@ -2,7 +2,7 @@ import { assertEquals } from "std/testing/asserts.ts";
 import { parseRss } from "./index.ts";
 
 Deno.test("parseRss dedupes and limits", () => {
-  const itemsXml = Array.from({ length: 12 }, (_ , i) =>
+  const itemsXml = Array.from({ length: 12 }, (_: unknown, i: number) =>
     `<item><title>${i}</title><link>u${i}</link><description>d</description><pubDate>2024-01-01</pubDate></item>`
   ).join("");
   const xml = `<rss><channel>${itemsXml}</channel></rss>`;

--- a/functions/recommendGigs/index.ts
+++ b/functions/recommendGigs/index.ts
@@ -37,7 +37,7 @@ export async function handler(req: Request): Promise<Response> {
   if (!supabaseUrl || !supabaseKey) {
     return new Response("Missing env vars", { status: 500 });
   }
-  const supabase = createClient(supabaseUrl, supabaseKey);
+  const supabase: any = createClient(supabaseUrl, supabaseKey);
   const { data: gigs } = await supabase.from("gigs").select();
   const { data: follows } = await supabase
     .from("follows")
@@ -50,8 +50,8 @@ export async function handler(req: Request): Promise<Response> {
 
   const recs = scoreGigs(
     gigs ?? [],
-    (follows ?? []).map((f) => f.artist_id),
-    (listens ?? []).map((l) => l.artist_id),
+    (follows ?? []).map((f: { artist_id: number }) => f.artist_id),
+    (listens ?? []).map((l: { artist_id: number }) => l.artist_id),
     city,
   );
   return new Response(JSON.stringify({ recommendations: recs }), {

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -8,6 +8,8 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
     "paths": {
       "@thecueroom/db": ["../packages/db/src"],
       "@thecueroom/schemas": ["../packages/schemas/src"],
@@ -15,5 +17,5 @@
     },
     "outDir": "dist"
   },
-  "include": ["**/*.ts"]
+  "include": ["**/*.ts", "**/*.d.ts"]
 }


### PR DESCRIPTION
## Summary
- add `deno-stubs.d.ts` to declare Deno globals and remote modules
- enable `.ts` extension imports and noEmit in `functions/tsconfig.json`
- type edge function code to satisfy strict TypeScript

## Testing
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68be0e481160832f815ffdabde059649