### PR TITLE
fix: restore landing artwork and logo

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -35,6 +35,14 @@ export default function Landing() {
             Learn More
           </button>
         </div>
+        <div className="mt-8">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={`${process.env.NEXT_PUBLIC_BASE_PATH ?? ''}/landing.svg`}
+            alt="TheCueRoom marketing landing"
+            className="h-auto w-full"
+          />
+        </div>
       </section>
 
       {/* What you get */}

--- a/apps/web/components/BrandLogo.tsx
+++ b/apps/web/components/BrandLogo.tsx
@@ -27,12 +27,7 @@ const RAW_LOGO_SVG = `
 
 export default function BrandLogo({
   className = "w-8 h-8",
-  title = "thecueRoom",
-}: { className?: string; title?: string }) {
-  return (
-    <div className={`${className} rounded-full bg-[#D1E231] flex items-center justify-center`} aria-label={title}>
-      <span className="text-black font-bold text-sm">tc</span>
-    </div>
-  );
+}: { className?: string }) {
+  return <div className={className} dangerouslySetInnerHTML={{ __html: RAW_LOGO_SVG }} />;
 }
 


### PR DESCRIPTION
## Summary
- restore marketing landing artwork sourced from `NEXT_PUBLIC_BASE_PATH`
- render raw SVG brand logo so tests can verify blink path

## Testing
- `npm run lint:web` *(fails: 12 errors, 2 warnings)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c01516d930832f9bd49343663fdd02