### PR TITLE
ci: ensure pnpm binary in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
           version: 9
           run_install: false
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Ensure pnpm is available
+        run: corepack prepare pnpm@9 --activate
 
       - name: Show versions
         run: |


### PR DESCRIPTION
## Summary
- ensure pnpm is activated in CI to fix missing executable error

## Testing
- `pnpm run ci:lint`
- `pnpm run ci:typecheck` *(fails: Cannot find name 'jest')*
- `pnpm run ci:test`


------
https://chatgpt.com/codex/tasks/task_e_68c2b9bb744c832fb4ff11e81fd12f65